### PR TITLE
Normalize property names to supported php names in the object encoder

### DIFF
--- a/src/Normalizer/PhpPropertyNameNormalizer.php
+++ b/src/Normalizer/PhpPropertyNameNormalizer.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Normalizer;
+
+use function Psl\Type\non_empty_string;
+
+final class PhpPropertyNameNormalizer
+{
+    public static function normalize(string $name): string
+    {
+        return self::camelCase($name, '{[^a-z0-9_]+}i');
+    }
+
+    /**
+     * @param literal-string $regexp
+     */
+    private static function camelCase(string $word, string $regexp):string
+    {
+        $parts = array_filter(preg_split($regexp, $word));
+        $keepUnchanged = array_shift($parts);
+        $parts = array_map('ucfirst', $parts);
+        array_unshift($parts, $keepUnchanged);
+
+        return non_empty_string()->assert(
+            implode('', $parts)
+        );
+    }
+}

--- a/tests/Unit/Encoder/ObjectEncoderTest.php
+++ b/tests/Unit/Encoder/ObjectEncoderTest.php
@@ -125,6 +125,47 @@ final class ObjectEncoderTest extends AbstractEncoderTests
             'xml' => '<tns:user xmlns:tns="https://test"><tns:active xmlns:tns="https://test">true</tns:active><tns:hat xmlns:tns="https://test"><tns:color xmlns:tns="https://test">green</tns:color></tns:hat></tns:user>',
             'data' => new User(active: true, hat: new Hat('green')),
         ];
+
+        yield 'unsupported-property-chars' => [
+            ...$baseConfig,
+            'context' => self::createContext(
+                $xsdType,
+                new TypeCollection(
+                    new Type(
+                        XsdType::create('user')
+                            ->withXmlTypeName('user')
+                            ->withXmlNamespace("https://test")
+                            ->withXmlNamespaceName('test')
+                            ->withXmlTargetNodeName('user')
+                            ->withMeta(
+                                static fn (TypeMeta $meta): TypeMeta => $meta
+                                    ->withIsQualified(true)
+                                    ->withIsElement(true)
+                            ),
+                        new PropertyCollection(
+                            new Property(
+                                'bon-jour',
+                                XsdType::create('bon-jour')
+                                    ->withXmlTypeName('boolean')
+                                    ->withXmlTargetNodeName('bon-jour')
+                                    ->withXmlNamespace(Xmlns::xsd()->value())
+                                    ->withXmlNamespaceName('xsd')
+                                    ->withMeta(
+                                        static fn (TypeMeta $meta): TypeMeta => $meta
+                                            ->withIsSimple(true)
+                                            ->withIsElement(true)
+                                            ->withIsQualified(true)
+                                    )
+                            ),
+                        )
+                    )
+                )
+            ),
+            'xml' => '<user><bon-jour>true</bon-jour></user>',
+            'data' => (object)[
+                'bonJour' => true,
+            ],
+        ];
     }
 
 

--- a/tests/Unit/Normalizer/PhpPropertyNameNormalizerTest.php
+++ b/tests/Unit/Normalizer/PhpPropertyNameNormalizerTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\Unit\Normalizer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Soap\Encoding\Normalizer\PhpPropertyNameNormalizer;
+
+#[CoversClass(PhpPropertyNameNormalizer::class)]
+final class PhpPropertyNameNormalizerTest extends TestCase
+{
+
+    /**
+     *
+     * @dataProvider provideCases
+     */
+    public function test_it_can_normalize(string $in, string $expected): void
+    {
+        static::assertEquals($expected, PhpPropertyNameNormalizer::normalize($in));
+    }
+
+    public static function provideCases()
+    {
+        yield ['prop1', 'prop1'];
+        yield ['final', 'final'];
+        yield ['Final', 'Final'];
+        yield ['UpperCased', 'UpperCased'];
+        yield ['my-./*prop_123', 'myProp_123'];
+        yield ['My-./*prop_123', 'MyProp_123'];
+        yield ['My-./final*prop_123', 'MyFinalProp_123'];
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | mprovement
| BC Break     | no
| Fixed issues | 

#### Summary

Fixes https://github.com/phpro/soap-client/issues/477
