### PR TITLE
Improved element xsi:type includeTargetNamespace logic

### DIFF
--- a/examples/encoders/simpleType/anyType-with-xsi-info.php
+++ b/examples/encoders/simpleType/anyType-with-xsi-info.php
@@ -6,7 +6,6 @@ use Soap\Encoding\Encoder\Feature\ElementContextEnhancer;
 use Soap\Encoding\Encoder\SimpleType\ScalarTypeEncoder;
 use Soap\Encoding\Encoder\XmlEncoder;
 use Soap\Encoding\EncoderRegistry;
-use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\WsdlReader\Model\Definitions\BindingUse;
 use VeeWee\Reflecta\Iso\Iso;
 
@@ -41,17 +40,10 @@ EncoderRegistry::default()
             /**
              * This method allows to change the context on the wrapping elementEncoder.
              * By forcing the bindingUse to `ENCODED`, we can make sure the xsi:type attribute is added.
-             * We also make sure the type is not qualified so that the xsi:type prefix xmlns is imported as well.
              */
             public function enhanceElementContext(Context $context): Context
             {
-                return $context
-                    ->withBindingUse(BindingUse::ENCODED)
-                    ->withType(
-                        $context->type->withMeta(
-                            static fn (TypeMeta $meta): TypeMeta => $meta->withIsQualified(false)
-                        )
-                    );
+                return $context->withBindingUse(BindingUse::ENCODED);
             }
         }
     );

--- a/src/Xml/Writer/ElementValueBuilder.php
+++ b/src/Xml/Writer/ElementValueBuilder.php
@@ -47,10 +47,14 @@ final class ElementValueBuilder
             return;
         }
 
+        $context = $this->context;
+        $type = $context->type;
+
         yield from (new XsiAttributeBuilder(
             $this->context,
-            XsiTypeDetector::detectFromValue($this->context, $this->value),
-            includeXsiTargetNamespace:  !$this->context->type->getMeta()->isQualified()->unwrapOr(false)
+            XsiTypeDetector::detectFromValue($context, $this->value),
+            includeXsiTargetNamespace: $type->getXmlTargetNamespace() !== $type->getXmlNamespace()
+                || !$type->getMeta()->isQualified()->unwrapOr(false)
         ))($writer);
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Improves on https://github.com/php-soap/encoding/pull/19:

Deciding based on `qualified` to import the namespace  can lead to issues:

The qualified property decides wether the element is prefixed or not and should therefor not solely be used to decide wether to import the xsi:type namespace. In this PR, an additional check of the `targetNamespace !== namespace` is added.

This makes configuring the encoder simpler as well:

```php
use Soap\Encoding\Encoder\Context;
use Soap\Encoding\Encoder\Feature\ElementContextEnhancer;
use Soap\Encoding\Encoder\SimpleType\ScalarTypeEncoder;
use Soap\Encoding\Encoder\XmlEncoder;
use Soap\Encoding\EncoderRegistry;
use Soap\Engine\Metadata\Model\TypeMeta;
use Soap\WsdlReader\Model\Definitions\BindingUse;
use VeeWee\Reflecta\Iso\Iso;

/**
 * This encoder can add xsi:type information to the XML element on xsd:anyType simpleTypes on literal encoded documents.
 *
 * <xsd:element minOccurs="0" maxOccurs="1" name="value" type="xsd:anyType" />
 *
 * Will Result in for example:
 *
 * <value
 *   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 *   xsi:type="xsds:int"
 *   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 * >
 *  789
 * </value>
 */

EncoderRegistry::default()
    ->addSimpleTypeConverter(
        'http://www.w3.org/2001/XMLSchema',
        'anyType',
        new class implements
            ElementContextEnhancer,
            XmlEncoder {
            public function iso(Context $context): Iso
            {
                return (new ScalarTypeEncoder())->iso($context);
            }

            /**
             * This method allows to change the context on the wrapping elementEncoder.
             * By forcing the bindingUse to `ENCODED`, we can make sure the xsi:type attribute is added.
             */
            public function enhanceElementContext(Context $context): Context
            {
                return $context->withBindingUse(BindingUse::ENCODED);
            }
        }
    );
```

