### PR TITLE
Add resolveXsiType

### DIFF
--- a/src/Encoder/ElementEncoder.php
+++ b/src/Encoder/ElementEncoder.php
@@ -38,7 +38,7 @@ final class ElementEncoder implements XmlEncoder
              */
             static fn (mixed $raw): string => (new XsdTypeXmlElementWriter())(
                 $context,
-                (new ElementValueBuilder($context, $typeEncoder, $raw))
+                (new ElementValueBuilder($typeEncoder instanceof Feature\ElementContextEnhancer ? ($context = $typeEncoder->resolveXsiType($context, $raw)) : $context, $typeEncoder, $raw))
             ),
             /**
              * @psalm-param non-empty-string|Element $xml

--- a/src/Encoder/Feature/ElementContextEnhancer.php
+++ b/src/Encoder/Feature/ElementContextEnhancer.php
@@ -16,4 +16,5 @@ use Soap\Encoding\Encoder\Context;
 interface ElementContextEnhancer
 {
     public function enhanceElementContext(Context $context): Context;
+    public function resolveXsiType(Context $context, mixed $value): Context;
 }


### PR DESCRIPTION
Add a xsi:type resolve method to the Element Context Enhancer in order to properly resolve types for XML generation

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | phpro/soap-client#539

#### Summary

To resolve type for xsi:type attribute I needed a value that I am passing to Encoder. That's why I suggesting to add resolveXsiType method in Element Context Enhancer interface.

#### Usage example

```php
    public function resolveXsiType(Context $context, mixed $value): Context
    {
        $xsd = Xmlns::xsd()->value();
        $resolvedType = null;

        if (is_a($value, DateTime::class)) {
            $resolvedType = $context->type->copy('dateTime')
                ->withXmlTypeName('dateTime')
                ->withXmlNamespaceName($context->namespaces->lookupNameFromNamespace($xsd)->unwrap())
                ->withXmlNamespace($xsd);
        }

        if (is_a($value, Date::class)) {
            $resolvedType = $context->type->copy('date')
                ->withXmlTypeName('date')
                ->withXmlNamespaceName($context->namespaces->lookupNameFromNamespace($xsd)->unwrap())
                ->withXmlNamespace($xsd);
        }

        if ($resolvedType !== null) {
            return $context->withType($resolvedType);
        }

        return $context;
    }
```