### PR TITLE
Introduce a XsiTypeCalculator feature that can enhance xsi:type calculation from the encoder

### DIFF
--- a/src/Encoder/Feature/DisregardXsiInformation.php
+++ b/src/Encoder/Feature/DisregardXsiInformation.php
@@ -3,6 +3,10 @@ declare(strict_types=1);
 
 namespace Soap\Encoding\Encoder\Feature;
 
+/**
+ * Tells the decoder to disregard any xsi:type information on the element when decoding an element.
+ * It will use the original provided decoder by default and won't try to guess the decoder based on xsi:type.
+ */
 interface DisregardXsiInformation
 {
 }

--- a/src/Encoder/Feature/XsiTypeCalculator.php
+++ b/src/Encoder/Feature/XsiTypeCalculator.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Encoder\Feature;
+
+use Soap\Encoding\Encoder\Context;
+
+/**
+ * By implementing this feature on your simpleType encoder, you can let the encoder decide what xsi:type attribute should be set to for a given value.
+ */
+interface XsiTypeCalculator
+{
+    /**
+     * @return string The value for the xsi:type attribute
+     *
+     * A sensible default fallback function is provided in the `ElementValueBuilder` class.
+     */
+    public function resolveXsiTypeForValue(Context $context, mixed $value): string;
+
+
+    /**
+     * Tells the XsiAttributeBuilder that the prefix of the xsi:type should be imported as a xmlns namespace.
+     *
+     * A sensible default fallback function is provided in the `ElementValueBuilder` class.
+     */
+    public function shouldIncludeXsiTargetNamespace(Context $context): bool;
+}

--- a/src/Xml/Writer/ElementValueBuilder.php
+++ b/src/Xml/Writer/ElementValueBuilder.php
@@ -5,7 +5,7 @@ namespace Soap\Encoding\Xml\Writer;
 
 use Generator;
 use Soap\Encoding\Encoder\Context;
-use Soap\Encoding\Encoder\Feature\CData;
+use Soap\Encoding\Encoder\Feature;
 use Soap\Encoding\Encoder\XmlEncoder;
 use Soap\Encoding\TypeInference\XsiTypeDetector;
 use Soap\WsdlReader\Model\Definitions\BindingUse;
@@ -48,14 +48,43 @@ final class ElementValueBuilder
         }
 
         $context = $this->context;
-        $type = $context->type;
+        [$xsiType, $includeXsiTargetNamespace] = match(true) {
+            $this->encoder instanceof Feature\XsiTypeCalculator => [
+                $this->encoder->resolveXsiTypeForValue($context, $this->value),
+                $this->encoder->shouldIncludeXsiTargetNamespace($context),
+            ],
+            default => [
+                self::resolveXsiTypeForValue($context, $this->value),
+                self::shouldIncludeXsiTargetNamespace($context),
+            ],
+        };
 
         yield from (new XsiAttributeBuilder(
             $this->context,
-            XsiTypeDetector::detectFromValue($context, $this->value),
-            includeXsiTargetNamespace: $type->getXmlTargetNamespace() !== $type->getXmlNamespace()
-                || !$type->getMeta()->isQualified()->unwrapOr(false)
+            $xsiType,
+            $includeXsiTargetNamespace,
         ))($writer);
+    }
+
+    /**
+     * Can be used as a default fallback function when implementing the XsiTypeCalculator interface.
+     * Tells the XsiAttributeBuilder what xsi:type attribute should be set to for a given value.
+     */
+    public static function resolveXsiTypeForValue(Context $context, mixed $value): string
+    {
+        return XsiTypeDetector::detectFromValue($context, $value);
+    }
+
+    /**
+     * Can be used as a default fallback function when implementing the XsiTypeCalculator interface.
+     * Tells the XsiAttributeBuilder that the prefix of the xsi:type should be imported as a xmlns namespace.
+     */
+    public static function shouldIncludeXsiTargetNamespace(Context $context): bool
+    {
+        $type = $context->type;
+
+        return $type->getXmlTargetNamespace() !== $type->getXmlNamespace()
+            || !$type->getMeta()->isQualified()->unwrapOr(false);
     }
 
     /**
@@ -66,7 +95,7 @@ final class ElementValueBuilder
         $encoded = $this->encoder->iso($this->context)->to($this->value);
 
         $builder = match (true) {
-            $this->encoder instanceof CData => cdata(value($encoded)),
+            $this->encoder instanceof Feature\CData => cdata(value($encoded)),
             default => value($encoded)
         };
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Provides an alternative solution for https://github.com/php-soap/encoding/pull/21


```php
use Soap\Encoding\Encoder\Context;
use Soap\Encoding\Encoder\Feature\ElementContextEnhancer;
use Soap\Encoding\Encoder\Feature\XsiTypeCalculator;
use Soap\Encoding\Encoder\SimpleType\ScalarTypeEncoder;
use Soap\Encoding\Encoder\XmlEncoder;
use Soap\Encoding\EncoderRegistry;
use Soap\Encoding\Xml\Writer\ElementValueBuilder;
use Soap\WsdlReader\Model\Definitions\BindingUse;
use VeeWee\Reflecta\Iso\Iso;

/**
 * This encoder can add xsi:type information to the XML element on xsd:anyType simpleTypes on literal encoded documents.
 *
 * <xsd:element minOccurs="0" maxOccurs="1" name="value" type="xsd:anyType" />
 *
 * Will Result in for example:
 *
 * <value
 *   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 *   xsi:type="xsds:int"
 *   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 * >
 *  789
 * </value>
 */

EncoderRegistry::default()
    ->addSimpleTypeConverter(
        'http://www.w3.org/2001/XMLSchema',
        'anyType',
        new class implements
            ElementContextEnhancer,
            XmlEncoder,
            XsiTypeCalculator {
            public function iso(Context $context): Iso
            {
                return (new ScalarTypeEncoder())->iso($context);
            }

            /**
             * This method allows to change the context on the wrapping elementEncoder.
             * By forcing the bindingUse to `ENCODED`, we can make sure the xsi:type attribute is added.
             */
            public function enhanceElementContext(Context $context): Context
            {
                return $context->withBindingUse(BindingUse::ENCODED);
            }

            /**
             * Can be used to fine-tune the xsi:type element.
             * For example, xsi:type="xsd:date" when dealing with value's like `DateTimeImmutable`.
             *
             * A default fallback function is provided in the ElementValueBuilder class.
             */
            public function resolveXsiTypeForValue(Context $context, mixed $value): string
            {
                return match (true) {
                    $value instanceof \DateTime => 'xsd:datetime',
                    $value instanceof \Date => 'xsd:date',
                    default => ElementValueBuilder::resolveXsiTypeForValue($context, $value),
                };
            }

            /**
             * Determines if the xmlns of the xsi:type prefix should be imported.
             * For example: xsd:date will import xmlns:xsd="...".
             *
             * A default fallback function is provided in the ElementValueBuilder class.
             */
            public function shouldIncludeXsiTargetNamespace(Context $context): bool
            {
                return ElementValueBuilder::shouldIncludeXsiTargetNamespace($context);
            }
        }
    );

```

