### PR TITLE
Allow not setting optional objects and arrays whilst encoding.

### DIFF
--- a/src/Encoder/EncoderDetector.php
+++ b/src/Encoder/EncoderDetector.php
@@ -51,6 +51,10 @@ final class EncoderDetector
             $encoder = new RepeatingElementEncoder($encoder);
         }
 
+        if (!$encoder instanceof Feature\OptionalAware && $meta->isNullable()->unwrapOr(false)) {
+            $encoder = new OptionalElementEncoder($encoder);
+        }
+
         $encoder = new ErrorHandlingEncoder($encoder);
 
         return $this->cache[$type] = $encoder;

--- a/src/Encoder/Feature/ListAware.php
+++ b/src/Encoder/Feature/ListAware.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Soap\Encoding\Encoder\Feature;
 
+/**
+ * Tells the encoder knows how to teal with list inputs.
+ */
 interface ListAware extends DisregardXsiInformation
 {
 }

--- a/src/Encoder/Feature/OptionalAware.php
+++ b/src/Encoder/Feature/OptionalAware.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Encoder\Feature;
+
+/**
+ * Tells the encoder knows about optional (nullable) values.
+ */
+interface OptionalAware extends DisregardXsiInformation
+{
+}

--- a/src/Encoder/OptionalElementEncoder.php
+++ b/src/Encoder/OptionalElementEncoder.php
@@ -13,7 +13,7 @@ use VeeWee\Xml\Xmlns\Xmlns;
  * @template T of mixed
  * @implements XmlEncoder<T, string>
  */
-final class OptionalElementEncoder implements XmlEncoder
+final class OptionalElementEncoder implements Feature\OptionalAware, XmlEncoder
 {
     /**
      * @param XmlEncoder<T, string> $elementEncoder

--- a/src/Encoder/RepeatingElementEncoder.php
+++ b/src/Encoder/RepeatingElementEncoder.php
@@ -12,7 +12,7 @@ use function Psl\Vec\map;
 
 /**
  * @template T
- * @implements XmlEncoder<iterable<array-key, T>, string>
+ * @implements XmlEncoder<iterable<array-key, T>|null, string>
  */
 final class RepeatingElementEncoder implements Feature\ListAware, XmlEncoder
 {
@@ -25,7 +25,7 @@ final class RepeatingElementEncoder implements Feature\ListAware, XmlEncoder
     }
 
     /**
-     * @return Iso<iterable<array-key, T>, string>
+     * @return Iso<iterable<array-key, T>|null, string>
      */
     public function iso(Context $context): Iso
     {
@@ -39,12 +39,12 @@ final class RepeatingElementEncoder implements Feature\ListAware, XmlEncoder
 
         return new Iso(
             /**
-             * @param iterable<array-key, T> $raw
+             * @param iterable<array-key, T>|null $raw
              */
-            static function (iterable $raw) use ($innerIso): string {
+            static function (iterable|null $raw) use ($innerIso): string {
                 return join(
                     map(
-                        $raw,
+                        $raw ?? [],
                         /**
                          * @param T $item
                          */

--- a/src/Encoder/SimpleType/EncoderDetector.php
+++ b/src/Encoder/SimpleType/EncoderDetector.php
@@ -39,9 +39,11 @@ final class EncoderDetector
         }
 
         if ($meta->isElement()->unwrapOr(false)) {
-            $encoder = new OptionalElementEncoder(
-                new ElementEncoder($encoder)
-            );
+            $encoder = new ElementEncoder($encoder);
+
+            if ($meta->isNullable()->unwrapOr(false)) {
+                $encoder = new OptionalElementEncoder($encoder);
+            }
         }
 
         return $encoder;

--- a/tests/PhpCompatibility/Implied/ImpliedSchema004Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema004Test.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+final class ImpliedSchema004Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType">
+        <complexType>
+            <sequence>
+                <element name="OptionalList" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                <element name="OptionalSimpleElement" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                <element name="OptionalObject" minOccurs="0">
+                    <complexType>
+                        <sequence>
+                            <element name="item" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                        </sequence>
+                    </complexType>
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object)[];
+    }
+
+    protected function expectDecoded(): mixed
+    {
+        return (object)[
+            'OptionalList' => [],
+            'OptionalSimpleElement' => null,
+            'OptionalObject' => null,
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:testType" />
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/Unit/Encoder/RepeatingElementEncoderTest.php
+++ b/tests/Unit/Encoder/RepeatingElementEncoderTest.php
@@ -82,4 +82,19 @@ final class RepeatingElementEncoderTest extends AbstractEncoderTests
 
         static::assertEquals(['world'], $actual);
     }
+
+    public function test_it_can_encode_from_null(): void
+    {
+        $encoder = new RepeatingElementEncoder(new ElementEncoder(new StringTypeEncoder()));
+        $context = self::createContext(
+            XsdType::guess('string')
+                ->withXmlTargetNodeName('hello')
+                ->withMeta(static fn (TypeMeta $meta): TypeMeta => $meta->withIsQualified(true))
+        );
+
+        $iso = $encoder->iso($context);
+        $actual = $iso->to(null);
+
+        static::assertSame('', $actual);
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no
| Fixed issues | Fixes #23 

#### Summary

Fixes #23.

This PR allows for not having to define optional sub-objects and arrays whilst encoding.
They are left out of the resulting encoded XML - as per XSD specification.
