### PR TITLE
Add support for <any />

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "azjezz/psl": "^3.0",
-        "veewee/reflecta": "~0.10",
+        "veewee/reflecta": "~0.11",
         "veewee/xml": "^3.3",
-        "php-soap/engine": "^2.13",
+        "php-soap/engine": "^2.14",
         "php-soap/wsdl": "^1.12",
         "php-soap/xml": "^1.8",
-        "php-soap/wsdl-reader": "~0.18"
+        "php-soap/wsdl-reader": "~0.20"
     },
     "require-dev": {
         "vimeo/psalm": "^5.26",

--- a/src/Encoder/AnyElementEncoder.php
+++ b/src/Encoder/AnyElementEncoder.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Encoding\Encoder;
+
+use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
+use Soap\Encoding\Xml\Reader\DocumentToLookupArrayReader;
+use Soap\Engine\Metadata\Model\Property;
+use Soap\Engine\Metadata\Model\Type;
+use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Lens\Lens;
+use function is_array;
+use function is_string;
+use function Psl\Dict\diff_by_key;
+use function Psl\Iter\first;
+use function Psl\Iter\reduce;
+use function Psl\Str\join;
+use function Psl\Type\string;
+use function Psl\Type\vec;
+
+/**
+ * @implements XmlEncoder<array|string|null, string>
+ *
+ * @psalm-import-type LookupArray from DocumentToLookupArrayReader
+ *
+ * @template-implements Feature\ProvidesObjectDecoderLens<LookupArray, ElementList>
+ */
+final class AnyElementEncoder implements Feature\ListAware, Feature\OptionalAware, Feature\ProvidesObjectDecoderLens, XmlEncoder
+{
+    /**
+     * This lens will be used to decode XML into an 'any' property.
+     * It will contain all the XML tags available in the object that is surrounding the 'any' property.
+     * Properties that are already known by the object, will be omitted.
+     *
+     * @return Lens<LookupArray, ElementList>
+     */
+    public static function createObjectDecoderLens(Type $parentType, Property $currentProperty): Lens
+    {
+        $omittedKeys = reduce(
+            $parentType->getProperties(),
+            static fn (array $omit, Property $property): array => [
+                ...$omit,
+                ...($property->getName() !== $currentProperty->getName() ? [$property->getName()] : []),
+            ],
+            []
+        );
+
+        /**
+         * @param LookupArray $data
+         * @return LookupArray
+         */
+        $omit = static fn (array $data): array => diff_by_key($data, array_flip($omittedKeys));
+
+        /** @var Lens<LookupArray, ElementList> */
+        return Lens::readonly(
+            /**
+             * @psalm-suppress MixedArgumentTypeCoercion - Psalm gets confused about the result of omit.
+             * @param LookupArray $data
+             */
+            static fn (array $data): ElementList => ElementList::fromLookupArray($omit($data))
+        );
+    }
+
+    /**
+     * @return Iso<array|string|null, string>
+     */
+    public function iso(Context $context): Iso
+    {
+        $meta = $context->type->getMeta();
+        $isNullable = $meta->isNullable()->unwrapOr(false);
+        $isList = $meta->isList()->unwrapOr(false);
+
+        return new Iso(
+            static fn (string|array|null $raw): string => match (true) {
+                is_string($raw) => $raw,
+                is_array($raw) => join(vec(string())->assert($raw), ''),
+                default => '',
+            },
+            /**
+             * @psalm-suppress DocblockTypeContradiction - Psalm gets confused about the return type of first() in default case.
+             * @psalm-return null|array<array-key, string>|string
+             */
+            static fn (ElementList|string $xml): mixed => match(true) {
+                is_string($xml) => $xml,
+                $isList && !$xml->hasElements() => [],
+                $isNullable && !$xml->hasElements() => null,
+                $isList => $xml->traverse(static fn (Element $element) => $element->value()),
+                default => first($xml->elements())?->value(),
+            }
+        );
+    }
+}

--- a/src/Encoder/ErrorHandlingEncoder.php
+++ b/src/Encoder/ErrorHandlingEncoder.php
@@ -12,9 +12,9 @@ use VeeWee\Reflecta\Iso\Iso;
  * @template-covariant TXml
  *
  * @implements XmlEncoder<TData, TXml>
- *
+ * @implements Feature\DecoratingEncoder<TData, TXml>
  */
-final class ErrorHandlingEncoder implements XmlEncoder
+final class ErrorHandlingEncoder implements Feature\DecoratingEncoder, XmlEncoder
 {
     /**
      * @param XmlEncoder<TData, TXml> $encoder
@@ -22,6 +22,14 @@ final class ErrorHandlingEncoder implements XmlEncoder
     public function __construct(
         private readonly XmlEncoder $encoder
     ) {
+    }
+
+    /**
+     * @return XmlEncoder<TData, TXml>
+     */
+    public function decoratedEncoder(): XmlEncoder
+    {
+        return $this->encoder;
     }
 
     /**

--- a/src/Encoder/Feature/DecoratingEncoder.php
+++ b/src/Encoder/Feature/DecoratingEncoder.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Encoding\Encoder\Feature;
+
+use Soap\Encoding\Encoder\XmlEncoder;
+
+/**
+ * @template-covariant TData
+ * @template-covariant TXml
+ */
+interface DecoratingEncoder
+{
+    /**
+     * @return XmlEncoder<TData, TXml>
+     */
+    public function decoratedEncoder(): XmlEncoder;
+}

--- a/src/Encoder/Feature/ProvidesObjectDecoderLens.php
+++ b/src/Encoder/Feature/ProvidesObjectDecoderLens.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Encoding\Encoder\Feature;
+
+use Soap\Engine\Metadata\Model\Property;
+use Soap\Engine\Metadata\Model\Type;
+use VeeWee\Reflecta\Lens\Lens;
+
+/**
+ * When an encoder implements this feature interface, it knows how to create a lens that will be applied on the parent data that is being decoded.
+ *
+ * @template-covariant S
+ * @template-covariant A
+ */
+interface ProvidesObjectDecoderLens
+{
+    /**
+     * @return Lens<S, A>
+     */
+    public static function createObjectDecoderLens(Type $parentType, Property $currentProperty): Lens;
+}

--- a/src/Encoder/Feature/ProvidesObjectEncoderLens.php
+++ b/src/Encoder/Feature/ProvidesObjectEncoderLens.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Soap\Encoding\Encoder\Feature;
+
+use Soap\Engine\Metadata\Model\Property;
+use Soap\Engine\Metadata\Model\Type;
+use VeeWee\Reflecta\Lens\Lens;
+
+/**
+ * When an encoder implements this feature interface, it knows how to create a lens that will be applied on the parent data that is being encoded.
+ *
+ * @template-covariant S
+ * @template-covariant A
+ */
+interface ProvidesObjectEncoderLens
+{
+    /**
+     * @return Lens<S, A>
+     */
+    public static function createObjectEncoderLens(Type $parentType, Property $currentProperty): Lens;
+}

--- a/src/EncoderRegistry.php
+++ b/src/EncoderRegistry.php
@@ -5,6 +5,7 @@ namespace Soap\Encoding;
 
 use Psl\Collection\MutableMap;
 use Soap\Encoding\ClassMap\ClassMapCollection;
+use Soap\Encoding\Encoder\AnyElementEncoder;
 use Soap\Encoding\Encoder\Context;
 use Soap\Encoding\Encoder\ElementEncoder;
 use Soap\Encoding\Encoder\EncoderDetector;
@@ -106,7 +107,6 @@ final class EncoderRegistry
                 $qNameFormatter($xsd, 'decimal') => new SimpleType\FloatTypeEncoder(),
 
                 // Scalar:
-                $qNameFormatter($xsd, 'any') => new SimpleType\ScalarTypeEncoder(),
                 $qNameFormatter($xsd, 'anyType') => new SimpleType\ScalarTypeEncoder(),
                 $qNameFormatter($xsd, 'anyXML') => new SimpleType\ScalarTypeEncoder(),
                 $qNameFormatter($xsd, 'anySimpleType') => new SimpleType\ScalarTypeEncoder(),
@@ -159,6 +159,9 @@ final class EncoderRegistry
 
                 // Apache Map
                 $qNameFormatter(ApacheMapDetector::NAMESPACE, 'Map') => new SoapEnc\ApacheMapEncoder(),
+
+                // Special XSD cases
+                $qNameFormatter($xsd, 'any') => new AnyElementEncoder(),
             ])
         );
     }

--- a/src/Xml/Reader/DocumentToLookupArrayReader.php
+++ b/src/Xml/Reader/DocumentToLookupArrayReader.php
@@ -9,10 +9,13 @@ use Soap\Encoding\Xml\Node\Element;
 use Soap\Encoding\Xml\Node\ElementList;
 use function VeeWee\Xml\Dom\Predicate\is_element;
 
+/**
+ * @psalm-type LookupArray = array<string, string|Element|ElementList>
+ */
 final class DocumentToLookupArrayReader
 {
     /**
-     * @return array<string, string|Element|ElementList>
+     * @return LookupArray
      */
     public function __invoke(Element $xml): array
     {
@@ -55,7 +58,7 @@ final class DocumentToLookupArrayReader
         /** @var \iterable<DOMAttr> $attributes */
         $attributes = $root->attributes;
         foreach ($attributes as $attribute) {
-            $key = $attribute->localName ?? 'unkown';
+            $key = $attribute->localName ?? 'unknown';
             $nodes[$key] = $attribute->value;
         }
 

--- a/tests/PhpCompatibility/Implied/ImpliedSchema005Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema005Test.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema005Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType">
+        <complexType>
+            <sequence>
+                <element name="customerName" type="xsd:string" />
+                <element name="customerEmail" type="xsd:string" />
+                <any processContents="strict" minOccurs="0" maxOccurs="3" />
+            </sequence>
+        </complexType>
+    </element>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object)[
+            'customerName' => 'John Doe',
+            'customerEmail' => 'john@doe.com',
+            'any' => [
+                '<hello>world</hello>',
+                '<hello>moon</hello>',
+            ],
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://test-uri/"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:testType">
+                        <customerName xsi:type="xsd:string">John Doe</customerName>
+                        <customerEmail xsi:type="xsd:string">john@doe.com</customerEmail>
+                        <hello>world</hello>
+                        <hello>moon</hello>
+                    </testParam>
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/PhpCompatibility/Implied/ImpliedSchema006Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema006Test.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema006Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType">
+        <complexType>
+            <sequence>
+                <any processContents="strict" minOccurs="0" maxOccurs="3" />
+            </sequence>
+        </complexType>
+    </element>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object)[
+            'any' => [
+                '<customerName>John Doe</customerName>',
+                '<customerEmail>john@doe.com</customerEmail>',
+                '<hello>world</hello>',
+                '<hello>moon</hello>',
+            ],
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:testType">
+                        <customerName>John Doe</customerName>
+                        <customerEmail>john@doe.com</customerEmail>
+                        <hello>world</hello>
+                        <hello>moon</hello>
+                    </testParam>
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/PhpCompatibility/Implied/ImpliedSchema007Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema007Test.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema007Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType">
+        <complexType>
+            <sequence>
+                <any processContents="strict" minOccurs="0" maxOccurs="1" />
+            </sequence>
+        </complexType>
+    </element>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object)[
+            'any' => null
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:testType" />
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/PhpCompatibility/Implied/ImpliedSchema008Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema008Test.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema008Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType">
+        <complexType>
+            <sequence>
+                <any processContents="strict" minOccurs="1" maxOccurs="1" />
+            </sequence>
+        </complexType>
+    </element>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object)[
+            'any' => '<hello/>'
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:testType">
+                        <hello/>
+                    </testParam>
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/Unit/Xml/Node/ElementListTest.php
+++ b/tests/Unit/Xml/Node/ElementListTest.php
@@ -39,4 +39,20 @@ final class ElementListTest extends TestCase
         static::assertCount(1, $list->elements());
         static::assertSame($xml, $list->elements()[0]->value());
     }
+
+    public function test_it_can_load_nested_list(): void
+    {
+        $list = ElementList::fromLookupArray([
+            'hello' => $hello = Element::fromString('<hello>world</hello>'),
+            'world' => '',
+            '_' => '',
+            'attr' => 'foo',
+            'list' => new ElementList(
+                $list1 = Element::fromString('<list>1</list>'),
+                $list2 = Element::fromString('<list>2</list>'),
+            )
+        ]);
+
+        static::assertSame([$hello, $list1, $list2], $list->elements());
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Add support for `<any />`

```xml
<element name="GetCustomerDetailsResponse">
    <complexType>
        <sequence>
            <element name="customerName" type="xsd:string" />
            <element name="customerEmail" type="xsd:string" />
            <any processContents="strict" minOccurs="0" maxOccurs="3" />
        </sequence>
    </complexType>
</element>
```

Converts (bidirectionally) into:

```
^ {#1769
  +"customerName": "John Doe"
  +"customerEmail": "john@doe.com"
  +"any": array:2 [
    0 => "<hello>world</hello>"
    1 => "<hello>worljohn</hello>"
  ]
}
```

For XML:

```xml
<x:GetCustomerDetailsResponse xmlns:x="http://example.com/customerdetails">
    <customerName>John Doe</customerName>
    <customerEmail>john@doe.com</customerEmail>
    <hello>world</hello>
    <hello>worljohn</hello>
</x:GetCustomerDetailsResponse>
```

This is the same as how PHP's ext-soap does the encoding.
If you want to overwrite the behaviour to for example return DOM nodes directly, you can overwrite the complex type that is added by default:

```php
$encoderRegistry->addComplexTypeConverter('http://www.w3.org/2001/XMLSchema', 'any', new \Soap\Encoding\Encoder\AnyElementEncoder())
```

This one can be used as a base for your own encoder.


