### PR TITLE
Detect nillable lists

### DIFF
--- a/src/Encoder/OptionalElementEncoder.php
+++ b/src/Encoder/OptionalElementEncoder.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 namespace Soap\Encoding\Encoder;
 
 use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Encoding\Xml\Writer\NilAttributeBuilder;
 use Soap\Encoding\Xml\Writer\XsdTypeXmlElementWriter;
 use VeeWee\Reflecta\Iso\Iso;
 use VeeWee\Xml\Xmlns\Xmlns;
+use function count;
+use function is_string;
 
 /**
  * @template T of mixed
@@ -31,6 +34,7 @@ final class OptionalElementEncoder implements Feature\ElementAware, Feature\Opti
         $type = $context->type;
         $meta = $type->getMeta();
         $elementIso = $this->elementEncoder->iso($context);
+        $isList = $meta->isList()->unwrapOr(false);
 
         if (!$meta->isNullable()->unwrapOr(false)) {
             return $elementIso;
@@ -48,17 +52,27 @@ final class OptionalElementEncoder implements Feature\ElementAware, Feature\Opti
             /**
              * @return T|null
              */
-            static function (Element|string $xml) use ($elementIso) : mixed {
+            static function (ElementList|Element|string $xml) use ($elementIso, $isList) : mixed {
                 if ($xml === '') {
                     return null;
                 }
 
-                $documentElement = ($xml instanceof Element ? $xml : Element::fromString($xml))->element();
-                if ($documentElement->getAttributeNS(Xmlns::xsi()->value(), 'nil') === 'true') {
+                $parsedXml = match(true) {
+                    $isList && is_string($xml) => ElementList::fromString('<list>'.$xml.'</list>'),
+                    is_string($xml) => Element::fromString($xml),
+                    default => $xml,
+                };
+
+                $documentElement = match (true) {
+                    $parsedXml instanceof ElementList && count($parsedXml) === 1 => $parsedXml->elements()[0]->element(),
+                    $parsedXml instanceof Element => $parsedXml->element(),
+                    default => null
+                };
+                if ($documentElement && $documentElement->getAttributeNS(Xmlns::xsi()->value(), 'nil') === 'true') {
                     return null;
                 }
 
-                /** @var Iso<T|null, Element|non-empty-string> $elementIso */
+                /** @var Iso<T|null, ElementList|Element|non-empty-string> $elementIso */
                 return $elementIso->from($xml);
             }
         );

--- a/src/Xml/Node/ElementList.php
+++ b/src/Xml/Node/ElementList.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 namespace Soap\Encoding\Xml\Node;
 
 use Closure;
+use Countable;
 use DOMElement;
 use Soap\Encoding\Xml\Reader\DocumentToLookupArrayReader;
 use Stringable;
 use VeeWee\Xml\Dom\Document;
+use function count;
 use function Psl\Iter\reduce;
 use function Psl\Vec\map;
 use function VeeWee\Xml\Dom\Locator\Element\children as readChildren;
@@ -15,7 +17,7 @@ use function VeeWee\Xml\Dom\Locator\Element\children as readChildren;
 /**
  * @psalm-import-type LookupArray from DocumentToLookupArrayReader
  */
-final class ElementList implements Stringable
+final class ElementList implements Countable, Stringable
 {
     /** @var list<Element> */
     private array $elements;
@@ -110,5 +112,10 @@ final class ElementList implements Stringable
     public function __toString()
     {
         return $this->value();
+    }
+
+    public function count(): int
+    {
+        return count($this->elements);
     }
 }

--- a/tests/PhpCompatibility/Implied/ImpliedSchema009Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema009Test.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema009Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType" minOccurs="0" maxOccurs="1" type="tns:ArrayOfCompany" />
+    <complexType name="ArrayOfCompany">
+        <sequence>
+            <element minOccurs="0" maxOccurs="unbounded" name="Company" nillable="true" type="tns:Company" />
+        </sequence>
+    </complexType>
+    <complexType name="Company">
+        <sequence>
+            <element minOccurs="1" maxOccurs="1" name="ID" type="xsd:int" />
+        </sequence>
+    </complexType>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object)[
+            'Company' => [
+                (object)['ID' => 0],
+                (object)['ID' => 1],
+            ],
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:ArrayOfCompany">
+                        <Company xsi:type="tns:Company">
+                            <ID xsi:type="xsd:int">0</ID>
+                        </Company>
+                        <Company xsi:type="tns:Company">
+                            <ID xsi:type="xsd:int">1</ID>
+                        </Company>
+                    </testParam>
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/PhpCompatibility/Implied/ImpliedSchema010Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema010Test.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema010Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType" minOccurs="0" maxOccurs="1" type="tns:ArrayOfCompany" />
+    <complexType name="ArrayOfCompany">
+        <sequence>
+            <element minOccurs="0" maxOccurs="unbounded" name="Company" nillable="true" type="tns:Company" />
+        </sequence>
+    </complexType>
+    <complexType name="Company">
+        <sequence>
+            <element minOccurs="1" maxOccurs="1" name="ID" type="xsd:int" />
+        </sequence>
+    </complexType>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object) [
+            'Company' => null,
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:ArrayOfCompany">
+                        <Company xsi:nil="true" />
+                    </testParam>
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/PhpCompatibility/Implied/ImpliedSchema011Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema011Test.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema011Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType" minOccurs="0" maxOccurs="1" type="tns:ArrayOfCompany" />
+    <complexType name="ArrayOfCompany">
+        <sequence>
+            <element minOccurs="0" maxOccurs="unbounded" name="Company" nillable="true" type="tns:Company" />
+        </sequence>
+    </complexType>
+    <complexType name="Company">
+        <sequence>
+            <element minOccurs="1" maxOccurs="1" name="ID" type="xsd:int" />
+        </sequence>
+    </complexType>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object) [
+            'Company' => [],
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:ArrayOfCompany" />
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/PhpCompatibility/Implied/ImpliedSchema012Test.php
+++ b/tests/PhpCompatibility/Implied/ImpliedSchema012Test.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Encoding\Test\PhpCompatibility\Implied;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Soap\Encoding\Decoder;
+use Soap\Encoding\Driver;
+use Soap\Encoding\Encoder;
+use Soap\Encoding\Test\PhpCompatibility\AbstractCompatibilityTests;
+
+#[CoversClass(Driver::class)]
+#[CoversClass(Encoder::class)]
+#[CoversClass(Decoder::class)]
+#[CoversClass(Encoder\AnyElementEncoder::class)]
+final class ImpliedSchema012Test extends AbstractCompatibilityTests
+{
+    protected string $schema = <<<EOXML
+    <element name="testType" minOccurs="0" maxOccurs="1" type="tns:ArrayOfCompany" />
+    <complexType name="ArrayOfCompany">
+        <sequence>
+            <element minOccurs="0" maxOccurs="unbounded" name="Company" nillable="true" type="tns:Company" />
+        </sequence>
+    </complexType>
+    <complexType name="Company">
+        <sequence>
+            <element minOccurs="1" maxOccurs="1" name="ID" type="xsd:int" />
+        </sequence>
+    </complexType>
+    EOXML;
+    protected string $type = 'type="tns:testType"';
+
+    protected function calculateParam(): mixed
+    {
+        return (object) [
+            'Company' => [
+                (object)['ID' => 0],
+            ],
+        ];
+    }
+
+    protected function expectXml(): string
+    {
+        return <<<XML
+         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:tns="http://test-uri/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                <tns:test>
+                    <testParam xsi:type="tns:ArrayOfCompany">
+                        <Company xsi:type="tns:Company">
+                            <ID xsi:type="xsd:int">0</ID>
+                        </Company>
+                    </testParam>
+                </tns:test>
+            </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+        XML;
+    }
+}

--- a/tests/Unit/Xml/Node/ElementListTest.php
+++ b/tests/Unit/Xml/Node/ElementListTest.php
@@ -55,4 +55,12 @@ final class ElementListTest extends TestCase
 
         static::assertSame([$hello, $list1, $list2], $list->elements());
     }
+
+    public function test_it_can_be_countded(): void
+    {
+        $list = new ElementList(Element::fromString('<hello>world</hello>'));
+
+        static::assertCount(1, $list->elements());
+        static::assertCount(1, $list);
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This PR introduces support for nil-able lists.

```xml
<complexType name="ArrayOfCompany">
        <sequence>
            <element minOccurs="0" maxOccurs="unbounded" name="Company" nillable="true" type="tns:Company" />
        </sequence>
    </complexType>
```

Rules:

* No `<Company />` occurence : `[]`
* Single `<Compani xsi:nil="true" :>`: `null`
* Single regular `<Company />`: `[object]`
* Multiple `<Company />`: `[object, ...]`
