### PR TITLE
Fix reading RPC responses

### DIFF
--- a/src/Xml/Reader/OperationReader.php
+++ b/src/Xml/Reader/OperationReader.php
@@ -8,8 +8,8 @@ use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\MethodMeta;
 use Soap\WsdlReader\Model\Definitions\BindingStyle;
 use function Psl\Vec\map;
+use function VeeWee\Xml\Dom\Assert\assert_element;
 use function VeeWee\Xml\Dom\Locator\Element\children as locateChildElements;
-use function VeeWee\Xml\Dom\Xpath\Configurator\namespaces;
 
 final class OperationReader
 {
@@ -25,21 +25,16 @@ final class OperationReader
      */
     public function __invoke(string $xml): ElementList
     {
-        $operationName = $this->meta->operationName()->unwrap();
-        $namespace = $this->meta->outputNamespace()->or($this->meta->targetNamespace())->unwrap();
         $bindingStyle = BindingStyle::tryFrom($this->meta->bindingStyle()->unwrapOr(BindingStyle::DOCUMENT->value));
 
         // The Response can contain out of multiple response parts.
         // Therefore, it is being wrapped by a central root element:
         $body = (new SoapEnvelopeReader())($xml);
         $bodyElement = $body->element();
-        $xpath = $body->document()->xpath(namespaces(['tns' => $namespace]));
 
         $elements = match($bindingStyle) {
             BindingStyle::DOCUMENT => locateChildElements($bodyElement),
-            BindingStyle::RPC => locateChildElements(
-                $xpath->querySingle('./tns:'.$operationName, $bodyElement)
-            )
+            BindingStyle::RPC => locateChildElements(assert_element($bodyElement->firstElementChild)),
         };
 
         return new ElementList(...map($elements, Element::fromDOMElement(...)));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

It is the response type name that is bein…g wrapped as element instead of the operation name

Fixes https://github.com/phpro/soap-client/issues/568
