### PR TITLE
GH-59: Fix ObjectEncoder dropping attributes with falsy values

### DIFF
--- a/src/Encoder/ObjectEncoder.php
+++ b/src/Encoder/ObjectEncoder.php
@@ -103,7 +103,7 @@ final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
                             $iso = $objectAccess->isos[$normalizePropertyName];
 
                             return match(true) {
-                                $isAttribute => $value ? (new AttributeBuilder(
+                                $isAttribute => $value !== null ? (new AttributeBuilder(
                                     $type,
                                     $iso->to($value)
                                 ))(...) : $defaultAction,

--- a/tests/Unit/Encoder/ObjectEncoderTest.php
+++ b/tests/Unit/Encoder/ObjectEncoderTest.php
@@ -109,6 +109,23 @@ final class ObjectEncoderTest extends AbstractEncoderTests
             'xml' => '<user active="true"><hat><color>green</color></hat></user>',
             'data' => new User(active: true, hat: new Hat('green')),
         ];
+        yield 'with-falsy-attribute' => [
+            ...$baseConfig,
+            'context' => self::createContext($xsdType, self::buildTypes(activeAsAttribute: true)),
+            'xml' => '<user active="false"><hat><color>green</color></hat></user>',
+            'data' => (object)[
+                'active' => false,
+                'hat' => (object)[
+                    'color' => 'green',
+                ],
+            ],
+        ];
+        yield 'class-objects-with-falsy-attribute' => [
+            'encoder' => new ObjectEncoder(User::class),
+            'context' => $withClassMap(self::createContext($xsdType, self::buildTypes(activeAsAttribute: true))),
+            'xml' => '<user active="false"><hat><color>green</color></hat></user>',
+            'data' => new User(active: false, hat: new Hat('green')),
+        ];
 
         yield 'wsdl-example-objects' => [
             ...$baseConfig,


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #59 

#### Summary

  - Fix truthiness check in ObjectEncoder that silently dropped XML attributes with falsy PHP values (false, 0, 0.0, "")                 
  - Replace $value ? with $value !== null ? so only genuinely absent attributes are skipped                                                    
  - Add test cases for falsy boolean attribute encoding/decoding   
