### PR TITLE
Backport: Fix ObjectEncoder dropping attributes with falsy values

### DIFF
--- a/src/Encoder/ObjectEncoder.php
+++ b/src/Encoder/ObjectEncoder.php
@@ -103,7 +103,7 @@ final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
                             $iso = $objectAccess->isos[$normalizePropertyName];
 
                             return match(true) {
-                                $isAttribute => $value ? (new AttributeBuilder(
+                                $isAttribute => $value !== null ? (new AttributeBuilder(
                                     $type,
                                     $iso->to($value)
                                 ))(...) : $defaultAction,

--- a/src/Normalizer/PhpPropertyNameNormalizer.php
+++ b/src/Normalizer/PhpPropertyNameNormalizer.php
@@ -10,6 +10,7 @@ use function array_unshift;
 use function count;
 use function preg_split;
 use function Psl\Type\non_empty_string;
+use function ucfirst;
 
 final class PhpPropertyNameNormalizer
 {
@@ -29,7 +30,7 @@ final class PhpPropertyNameNormalizer
         }
 
         $keepUnchanged = array_shift($parts);
-        $parts = array_map(\ucfirst(...), $parts);
+        $parts = array_map(ucfirst(...), $parts);
         array_unshift($parts, $keepUnchanged);
 
         return non_empty_string()->assert(

--- a/tests/Unit/Encoder/ObjectEncoderTest.php
+++ b/tests/Unit/Encoder/ObjectEncoderTest.php
@@ -109,6 +109,23 @@ final class ObjectEncoderTest extends AbstractEncoderTests
             'xml' => '<user active="true"><hat><color>green</color></hat></user>',
             'data' => new User(active: true, hat: new Hat('green')),
         ];
+        yield 'with-falsy-attribute' => [
+            ...$baseConfig,
+            'context' => self::createContext($xsdType, self::buildTypes(activeAsAttribute: true)),
+            'xml' => '<user active="false"><hat><color>green</color></hat></user>',
+            'data' => (object)[
+                'active' => false,
+                'hat' => (object)[
+                    'color' => 'green',
+                ],
+            ],
+        ];
+        yield 'class-objects-with-falsy-attribute' => [
+            'encoder' => new ObjectEncoder(User::class),
+            'context' => $withClassMap(self::createContext($xsdType, self::buildTypes(activeAsAttribute: true))),
+            'xml' => '<user active="false"><hat><color>green</color></hat></user>',
+            'data' => new User(active: false, hat: new Hat('green')),
+        ];
 
         yield 'wsdl-example-objects' => [
             ...$baseConfig,


### PR DESCRIPTION
Backports the fix from #60 to the `0.31.x` branch, so a `0.31.1` patch release can be tagged for projects still on PHP 8.3 that cannot upgrade to `0.32.x` (which raised the minimum PHP version to 8.4 and bumped several dependencies).

Closes #61.

Credit to @ademarco for the original backport patch (openeuropa/php-soap-encoding#1).

## Changes

- One-line fix in `ObjectEncoder.php`: use `$value !== null` instead of a truthy check, so falsy attribute values (`false`, `0`, `0.0`, `""`) are still encoded.
- Test coverage for falsy attribute values.

## Test plan

- [x] `vendor/bin/phpunit` passes locally (564 tests, 1156 assertions)