### PR TITLE
Migrate to STAB optics (Iso<S,T,A,B> / Lens<S,T,A,B>)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "php-standard-library/str": "^6.1",
         "php-standard-library/type": "^6.1",
         "php-standard-library/vec": "^6.1",
-        "veewee/reflecta": "dev-feature/stab-optics as 0.19.0",
+        "veewee/reflecta": "^1.0.0",
         "veewee/xml": "^4.10",
         "php-soap/engine": "^2.20",
         "php-soap/wsdl": "^1.19",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "php-standard-library/str": "^6.1",
         "php-standard-library/type": "^6.1",
         "php-standard-library/vec": "^6.1",
-        "veewee/reflecta": "~0.16",
+        "veewee/reflecta": "dev-feature/stab-optics as 0.19.0",
         "veewee/xml": "^4.10",
         "php-soap/engine": "^2.20",
         "php-soap/wsdl": "^1.19",

--- a/src/Encoder/AnyElementEncoder.php
+++ b/src/Encoder/AnyElementEncoder.php
@@ -19,11 +19,11 @@ use function Psl\Type\string;
 use function Psl\Type\vec;
 
 /**
- * @implements XmlEncoder<array|string|null, string>
+ * @implements XmlEncoder<array|string|null, array<array-key, string>|string|null, string, ElementList|string>
  *
  * @psalm-import-type LookupArray from DocumentToLookupArrayReader
  *
- * @template-implements Feature\ProvidesObjectDecoderLens<LookupArray, ElementList>
+ * @template-implements Feature\ProvidesObjectDecoderLens<LookupArray, LookupArray, ElementList, ElementList>
  */
 final class AnyElementEncoder implements Feature\ListAware, Feature\OptionalAware, Feature\ProvidesObjectDecoderLens, XmlEncoder
 {
@@ -32,7 +32,7 @@ final class AnyElementEncoder implements Feature\ListAware, Feature\OptionalAwar
      * It will contain all the XML tags available in the object that is surrounding the 'any' property.
      * Properties that are already known by the object, will be omitted.
      *
-     * @return Lens<LookupArray, ElementList>
+     * @return Lens<LookupArray, LookupArray, ElementList, ElementList>
      */
     public static function createObjectDecoderLens(Type $parentType, Property $currentProperty): Lens
     {
@@ -51,7 +51,7 @@ final class AnyElementEncoder implements Feature\ListAware, Feature\OptionalAwar
          */
         $omit = static fn (array $data): array => diff_by_key($data, array_flip($omittedKeys));
 
-        /** @var Lens<LookupArray, ElementList> */
+        /** @var Lens<LookupArray, LookupArray, ElementList, ElementList> */
         return Lens::readonly(
             /**
              * @psalm-suppress MixedArgumentTypeCoercion - Psalm gets confused about the result of omit.
@@ -62,7 +62,7 @@ final class AnyElementEncoder implements Feature\ListAware, Feature\OptionalAwar
     }
 
     /**
-     * @return Iso<array|string|null, string>
+     * @return Iso<array|string|null, array<array-key, string>|string|null, string, ElementList|string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/ElementEncoder.php
+++ b/src/Encoder/ElementEncoder.php
@@ -10,12 +10,12 @@ use Soap\Encoding\Xml\Writer\XsdTypeXmlElementWriter;
 use VeeWee\Reflecta\Iso\Iso;
 
 /**
- * @implements XmlEncoder<mixed, string>
+ * @implements XmlEncoder<mixed, mixed, non-empty-string, Element|non-empty-string>
  */
 final class ElementEncoder implements Feature\ElementAware, XmlEncoder
 {
     /**
-     * @param XmlEncoder<mixed, string> $typeEncoder
+     * @param XmlEncoder<mixed, mixed, string, string> $typeEncoder
      */
     public function __construct(
         private readonly XmlEncoder $typeEncoder
@@ -23,7 +23,7 @@ final class ElementEncoder implements Feature\ElementAware, XmlEncoder
     }
 
     /**
-     * @return Iso<mixed, string>
+     * @return Iso<mixed, mixed, non-empty-string, Element|non-empty-string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/EncoderDetector.php
+++ b/src/Encoder/EncoderDetector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Soap\Encoding\Encoder;
 
 use Soap\Encoding\Cache\ScopedCache;
+use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\XsdType;
 use stdClass;
 
@@ -18,7 +20,7 @@ final class EncoderDetector
     }
 
     /**
-     * @return ScopedCache<XsdType, XmlEncoder<mixed, string>>
+     * @return ScopedCache<XsdType, XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null>>
      *
      * @psalm-suppress LessSpecificReturnStatement, MoreSpecificReturnType, MixedReturnStatement
      */
@@ -30,9 +32,7 @@ final class EncoderDetector
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
-     *
-     * @psalm-suppress InvalidArgument, InvalidReturnType, PossiblyInvalidArgument, InvalidReturnStatement - The simple type detector could return string|null, but should not be an issue here.
+     * @return XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null>
      */
     public function __invoke(Context $context): XmlEncoder
     {
@@ -44,9 +44,7 @@ final class EncoderDetector
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
-     *
-     * @psalm-suppress PossiblyInvalidArgument - The simple type detector could return string|null, but should not be an issue here.
+     * @return XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null>
      */
     private function detect(Context $context): XmlEncoder
     {
@@ -62,8 +60,8 @@ final class EncoderDetector
     }
 
     /**
-     * @param XmlEncoder<mixed, string> $encoder
-     * @return XmlEncoder<mixed, string>
+     * @param XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null> $encoder
+     * @return XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null>
      */
     private function enhanceEncoder(Context $context, XmlEncoder $encoder): XmlEncoder
     {
@@ -86,7 +84,7 @@ final class EncoderDetector
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
+     * @return XmlEncoder<mixed, mixed, string, Element|ElementList|string>
      */
     private function detectComplexTypeEncoder(XsdType $type, Context $context): XmlEncoder
     {

--- a/src/Encoder/ErrorHandlingEncoder.php
+++ b/src/Encoder/ErrorHandlingEncoder.php
@@ -8,16 +8,18 @@ use Throwable;
 use VeeWee\Reflecta\Iso\Iso;
 
 /**
- * @template-covariant TData
- * @template-covariant TXml
+ * @template TDataIn
+ * @template TDataOut
+ * @template TXmlOut
+ * @template TXmlIn
  *
- * @implements XmlEncoder<TData, TXml>
- * @implements Feature\DecoratingEncoder<TData, TXml>
+ * @implements XmlEncoder<TDataIn, TDataOut, TXmlOut, TXmlIn>
+ * @implements Feature\DecoratingEncoder<TDataIn, TDataOut, TXmlOut, TXmlIn>
  */
 final class ErrorHandlingEncoder implements Feature\DecoratingEncoder, XmlEncoder
 {
     /**
-     * @param XmlEncoder<TData, TXml> $encoder
+     * @param XmlEncoder<TDataIn, TDataOut, TXmlOut, TXmlIn> $encoder
      */
     public function __construct(
         private readonly XmlEncoder $encoder
@@ -25,7 +27,7 @@ final class ErrorHandlingEncoder implements Feature\DecoratingEncoder, XmlEncode
     }
 
     /**
-     * @return XmlEncoder<TData, TXml>
+     * @return XmlEncoder<TDataIn, TDataOut, TXmlOut, TXmlIn>
      */
     public function decoratedEncoder(): XmlEncoder
     {
@@ -33,7 +35,7 @@ final class ErrorHandlingEncoder implements Feature\DecoratingEncoder, XmlEncode
     }
 
     /**
-     * @return Iso<TData, TXml>
+     * @return Iso<TDataIn, TDataOut, TXmlOut, TXmlIn>
      */
     public function iso(Context $context): Iso
     {
@@ -41,8 +43,8 @@ final class ErrorHandlingEncoder implements Feature\DecoratingEncoder, XmlEncode
 
         return new Iso(
             /**
-             * @psalm-param TData $value
-             * @psalm-return TXml
+             * @psalm-param TDataIn $value
+             * @psalm-return TXmlOut
              */
             static function (mixed $value) use ($innerIso, $context): mixed {
                 try {
@@ -52,8 +54,8 @@ final class ErrorHandlingEncoder implements Feature\DecoratingEncoder, XmlEncode
                 }
             },
             /**
-             * @psalm-param TXml $value
-             * @psalm-return TData
+             * @psalm-param TXmlIn $value
+             * @psalm-return TDataOut
              */
             static function (mixed $value) use ($innerIso, $context): mixed {
                 try {

--- a/src/Encoder/Feature/DecoratingEncoder.php
+++ b/src/Encoder/Feature/DecoratingEncoder.php
@@ -5,13 +5,15 @@ namespace Soap\Encoding\Encoder\Feature;
 use Soap\Encoding\Encoder\XmlEncoder;
 
 /**
- * @template-covariant TData
- * @template-covariant TXml
+ * @template-covariant TDataIn
+ * @template-covariant TDataOut
+ * @template-covariant TXmlOut
+ * @template-covariant TXmlIn
  */
 interface DecoratingEncoder
 {
     /**
-     * @return XmlEncoder<TData, TXml>
+     * @return XmlEncoder<TDataIn, TDataOut, TXmlOut, TXmlIn>
      */
     public function decoratedEncoder(): XmlEncoder;
 }

--- a/src/Encoder/Feature/ProvidesObjectDecoderLens.php
+++ b/src/Encoder/Feature/ProvidesObjectDecoderLens.php
@@ -4,18 +4,20 @@ namespace Soap\Encoding\Encoder\Feature;
 
 use Soap\Engine\Metadata\Model\Property;
 use Soap\Engine\Metadata\Model\Type;
-use VeeWee\Reflecta\Lens\Lens;
+use VeeWee\Reflecta\Lens\LensInterface;
 
 /**
  * When an encoder implements this feature interface, it knows how to create a lens that will be applied on the parent data that is being decoded.
  *
- * @template-covariant S
+ * @template-covariant S of array<array-key, mixed>
+ * @template-covariant T of array<array-key, mixed>
  * @template-covariant A
+ * @template-covariant B
  */
 interface ProvidesObjectDecoderLens
 {
     /**
-     * @return Lens<S, A>
+     * @return LensInterface<S, T, A, B>
      */
-    public static function createObjectDecoderLens(Type $parentType, Property $currentProperty): Lens;
+    public static function createObjectDecoderLens(Type $parentType, Property $currentProperty): LensInterface;
 }

--- a/src/Encoder/Feature/ProvidesObjectEncoderLens.php
+++ b/src/Encoder/Feature/ProvidesObjectEncoderLens.php
@@ -4,18 +4,20 @@ namespace Soap\Encoding\Encoder\Feature;
 
 use Soap\Engine\Metadata\Model\Property;
 use Soap\Engine\Metadata\Model\Type;
-use VeeWee\Reflecta\Lens\Lens;
+use VeeWee\Reflecta\Lens\LensInterface;
 
 /**
  * When an encoder implements this feature interface, it knows how to create a lens that will be applied on the parent data that is being encoded.
  *
- * @template-covariant S
+ * @template-covariant S of object
+ * @template-covariant T of object
  * @template-covariant A
+ * @template-covariant B
  */
 interface ProvidesObjectEncoderLens
 {
     /**
-     * @return Lens<S, A>
+     * @return LensInterface<S, T, A, B>
      */
-    public static function createObjectEncoderLens(Type $parentType, Property $currentProperty): Lens;
+    public static function createObjectEncoderLens(Type $parentType, Property $currentProperty): LensInterface;
 }

--- a/src/Encoder/FixedIsoEncoder.php
+++ b/src/Encoder/FixedIsoEncoder.php
@@ -2,27 +2,29 @@
 
 namespace Soap\Encoding\Encoder;
 
-use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 
 /**
  * @template S
+ * @template T
  * @template A
- * @implements XmlEncoder<S, A>
+ * @template B
+ * @implements XmlEncoder<S, T, A, B>
  */
 final readonly class FixedIsoEncoder implements XmlEncoder
 {
     /**
-     * @param Iso<S, A> $iso
+     * @param IsoInterface<S, T, A, B> $iso
      */
     public function __construct(
-        private Iso $iso,
+        private IsoInterface $iso,
     ) {
     }
 
     /**
-     * @return Iso<S, A>
+     * @return IsoInterface<S, T, A, B>
      */
-    public function iso(Context $context): Iso
+    public function iso(Context $context): IsoInterface
     {
         return $this->iso;
     }

--- a/src/Encoder/MatchingValueEncoder.php
+++ b/src/Encoder/MatchingValueEncoder.php
@@ -11,18 +11,18 @@ use function Psl\invariant;
  * This encoder can be used to select an encoder based on the value being encoded.
  * For decoding, it will always use the default encoder.
  *
- * @psalm-type MatchedEncoderInfo = Context | array{0: Context, 1 ?: XmlEncoder<mixed, string>|null}
+ * @psalm-type MatchedEncoderInfo = Context | array{0: Context, 1 ?: XmlEncoder<mixed, mixed, string, Element|string>|null}
  * @psalm-type MatchingEncoderDetector = \Closure(Context, mixed): MatchedEncoderInfo
  *
  * @psalm-suppress UnusedClass
  *
- * @implements XmlEncoder<mixed, string>
+ * @implements XmlEncoder<mixed, mixed, string, Element|string>
  */
 final readonly class MatchingValueEncoder implements XmlEncoder
 {
     /**
      * @param MatchingEncoderDetector $encoderDetector
-     * @param XmlEncoder<mixed, string> $defaultEncoder
+     * @param XmlEncoder<mixed, mixed, string, Element|string> $defaultEncoder
      */
     public function __construct(
         private Closure $encoderDetector,
@@ -32,7 +32,6 @@ final readonly class MatchingValueEncoder implements XmlEncoder
 
     public function iso(Context $context): Iso
     {
-        /** @var Iso<string, mixed> $defaultIso */
         $defaultIso = $this->defaultEncoder->iso($context);
 
         return new Iso(

--- a/src/Encoder/Method/RequestEncoder.php
+++ b/src/Encoder/Method/RequestEncoder.php
@@ -19,12 +19,12 @@ use function Psl\Vec\map_with_key;
 use function VeeWee\Reflecta\Lens\index;
 
 /**
- * @template-implements SoapMethodEncoder<list<mixed>, non-empty-string>
+ * @template-implements SoapMethodEncoder<list<mixed>, list<mixed>, non-empty-string, non-empty-string>
  */
 final class RequestEncoder implements SoapMethodEncoder
 {
     /**
-     * @return Iso<list<mixed>, non-empty-string>
+     * @return Iso<list<mixed>, list<mixed>, non-empty-string, non-empty-string>
      */
     public function iso(MethodContext $context): Iso
     {
@@ -35,7 +35,7 @@ final class RequestEncoder implements SoapMethodEncoder
                 ->unwrapOr(BindingUse::LITERAL)
         );
 
-        /** @var Iso<list<mixed>, non-empty-string> */
+        /** @var Iso<list<mixed>, list<mixed>, non-empty-string, non-empty-string> */
         return new Iso(
             /**
              * @param list<mixed> $arguments

--- a/src/Encoder/Method/ResponseEncoder.php
+++ b/src/Encoder/Method/ResponseEncoder.php
@@ -17,12 +17,12 @@ use function Psl\invariant;
 use function Psl\Vec\map;
 
 /**
- * @template-implements SoapMethodEncoder<mixed, string>
+ * @template-implements SoapMethodEncoder<list<mixed>, list<mixed>, string, string>
  */
 final class ResponseEncoder implements SoapMethodEncoder
 {
     /**
-     * @return Iso<mixed, string>
+     * @return Iso<list<mixed>, list<mixed>, string, string>
      */
     public function iso(MethodContext $context): Iso
     {
@@ -33,7 +33,7 @@ final class ResponseEncoder implements SoapMethodEncoder
                 ->unwrapOr(BindingUse::LITERAL)
         );
 
-        /** @var Iso<list<mixed>, string> */
+        /** @var Iso<list<mixed>, list<mixed>, string, string> */
         return new Iso(
             /**
              * @param list<mixed> $arguments

--- a/src/Encoder/Method/SoapMethodEncoder.php
+++ b/src/Encoder/Method/SoapMethodEncoder.php
@@ -2,16 +2,18 @@
 
 namespace Soap\Encoding\Encoder\Method;
 
-use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 
 /**
- * @template-covariant TData
- * @template-covariant TXml
+ * @template-covariant TDataIn
+ * @template-covariant TDataOut
+ * @template-covariant TXmlOut
+ * @template-covariant TXmlIn
  */
 interface SoapMethodEncoder
 {
     /**
-     * @return Iso<TData, TXml>
+     * @return IsoInterface<TDataIn, TDataOut, TXmlOut, TXmlIn>
      */
-    public function iso(MethodContext $context): Iso;
+    public function iso(MethodContext $context): IsoInterface;
 }

--- a/src/Encoder/ObjectAccess.php
+++ b/src/Encoder/ObjectAccess.php
@@ -7,11 +7,13 @@ use Soap\Encoding\Cache\ScopedCache;
 use Soap\Encoding\EncoderRegistry;
 use Soap\Encoding\Normalizer\PhpPropertyNameNormalizer;
 use Soap\Encoding\TypeInference\ComplexTypeBuilder;
+use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\Property;
 use Soap\Engine\Metadata\Model\Type;
 use Soap\Engine\Metadata\Model\TypeMeta;
-use VeeWee\Reflecta\Iso\Iso;
-use VeeWee\Reflecta\Lens\Lens;
+use VeeWee\Reflecta\Iso\IsoInterface;
+use VeeWee\Reflecta\Lens\LensInterface;
 use function Psl\Vec\sort_by;
 use function VeeWee\Reflecta\Lens\index;
 use function VeeWee\Reflecta\Lens\optional;
@@ -21,9 +23,9 @@ final class ObjectAccess
 {
     /**
      * @param array<string, Property> $properties
-     * @param array<string, Lens<object, mixed>> $encoderLenses
-     * @param array<string, Lens<array, mixed>> $decoderLenses
-     * @param array<string, Iso<mixed, string>> $isos
+     * @param array<string, LensInterface<object|null, object|null, mixed, mixed>> $encoderLenses
+     * @param array<string, LensInterface<array<array-key, mixed>|null, array<array-key, mixed>|null, mixed, mixed>> $decoderLenses
+     * @param array<string, IsoInterface<mixed, mixed, string|null, Element|ElementList|string|null>> $isos
      */
     public function __construct(
         public readonly array $properties,
@@ -104,7 +106,7 @@ final class ObjectAccess
     }
 
     /**
-     * @return Lens<object, mixed>
+     * @return LensInterface<object|null, object|null, mixed, mixed>
      */
     private static function createEncoderLensForType(
         bool $shouldLensBeOptional,
@@ -112,19 +114,18 @@ final class ObjectAccess
         XmlEncoder $encoder,
         Type $type,
         Property $property,
-    ): Lens {
+    ): LensInterface {
         $lens = match (true) {
             $encoder instanceof Feature\DecoratingEncoder => self::createEncoderLensForType($shouldLensBeOptional, $normalizedName, $encoder->decoratedEncoder(), $type, $property),
             $encoder instanceof Feature\ProvidesObjectEncoderLens => $encoder::createObjectEncoderLens($type, $property),
             default => property($normalizedName)
         };
 
-        /** @var Lens<object, mixed> */
         return $shouldLensBeOptional ? optional($lens) : $lens;
     }
 
     /**
-     * @return Lens<array, mixed>
+     * @return LensInterface<array<array-key, mixed>|null, array<array-key, mixed>|null, mixed, mixed>
      */
     private static function createDecoderLensForType(
         bool $shouldLensBeOptional,
@@ -132,14 +133,13 @@ final class ObjectAccess
         XmlEncoder $encoder,
         Type $type,
         Property $property,
-    ): Lens {
+    ): LensInterface {
         $lens = match(true) {
             $encoder instanceof Feature\DecoratingEncoder => self::createDecoderLensForType($shouldLensBeOptional, $name, $encoder->decoratedEncoder(), $type, $property),
             $encoder instanceof Feature\ProvidesObjectDecoderLens => $encoder::createObjectDecoderLens($type, $property),
             default => index($name),
         };
 
-        /** @var Lens<array, mixed> */
         return $shouldLensBeOptional ? optional($lens) : $lens;
     }
 

--- a/src/Encoder/ObjectEncoder.php
+++ b/src/Encoder/ObjectEncoder.php
@@ -13,7 +13,7 @@ use Soap\Encoding\Xml\Writer\XsdTypeXmlElementWriter;
 use Soap\Encoding\Xml\Writer\XsiAttributeBuilder;
 use Soap\Engine\Metadata\Model\Property;
 use VeeWee\Reflecta\Iso\Iso;
-use VeeWee\Reflecta\Lens\Lens;
+use VeeWee\Reflecta\Lens\LensInterface;
 use function is_array;
 use function Psl\Dict\map_with_key;
 use function Psl\Fun\lazy;
@@ -25,7 +25,7 @@ use function VeeWee\Xml\Writer\Builder\value as buildValue;
 /**
  * @template TObj extends object
  *
- * @implements XmlEncoder<TObj|array, non-empty-string>
+ * @implements XmlEncoder<TObj|array, TObj, non-empty-string, Element|non-empty-string>
  */
 final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
 {
@@ -38,7 +38,7 @@ final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
     }
 
     /**
-     * @return Iso<TObj|array, non-empty-string>
+     * @return Iso<TObj|array, TObj, non-empty-string, Element|non-empty-string>
      */
     public function iso(Context $context): Iso
     {
@@ -105,12 +105,12 @@ final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
                             return match(true) {
                                 $isAttribute => $value !== null ? (new AttributeBuilder(
                                     $type,
-                                    $iso->to($value)
+                                    (string) $iso->to($value)
                                 ))(...) : $defaultAction,
                                 $property->getName() === '_' => $value !== null
-                                    ? buildValue($iso->to($value))
+                                    ? buildValue((string) $iso->to($value))
                                     : (new NilAttributeBuilder())(...),
-                                default => raw($iso->to($value))
+                                default => raw((string) $iso->to($value))
                             };
                         }
                     )
@@ -125,7 +125,7 @@ final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
     private function from(Context $context, ObjectAccess $objectAccess, Element $data): object
     {
         $nodes = (new DocumentToLookupArrayReader())($data);
-        /** @var Iso<TObj, array<string, mixed>> $objectData */
+        /** @var Iso<TObj, TObj, array<string, mixed>, array<string, mixed>> $objectData */
         $objectData = object_data($this->className);
 
         return $objectData->from(
@@ -153,7 +153,7 @@ final class ObjectEncoder implements Feature\ElementAware, XmlEncoder
         );
     }
 
-    private static function runLens(Lens $lens, mixed $data, mixed $default = null): mixed
+    private static function runLens(LensInterface $lens, mixed $data, mixed $default = null): mixed
     {
         try {
             /** @var mixed */

--- a/src/Encoder/OptionalElementEncoder.php
+++ b/src/Encoder/OptionalElementEncoder.php
@@ -8,18 +8,19 @@ use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Encoding\Xml\Writer\NilAttributeBuilder;
 use Soap\Encoding\Xml\Writer\XsdTypeXmlElementWriter;
 use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 use VeeWee\Xml\Xmlns\Xmlns;
 use function count;
 use function is_string;
 
 /**
  * @template T of mixed
- * @implements XmlEncoder<T, string>
+ * @implements XmlEncoder<T, T, string, ElementList|Element|string>
  */
 final class OptionalElementEncoder implements Feature\ElementAware, Feature\OptionalAware, XmlEncoder
 {
     /**
-     * @param XmlEncoder<T, string> $elementEncoder
+     * @param XmlEncoder<T, T, string|null, ElementList|Element|string|null> $elementEncoder
      */
     public function __construct(
         private readonly XmlEncoder $elementEncoder
@@ -27,12 +28,13 @@ final class OptionalElementEncoder implements Feature\ElementAware, Feature\Opti
     }
 
     /**
-     * @return Iso<T, string>
+     * @return IsoInterface<T, T, string, ElementList|Element|string>
      */
-    public function iso(Context $context): Iso
+    public function iso(Context $context): IsoInterface
     {
         $type = $context->type;
         $meta = $type->getMeta();
+        /** @var IsoInterface<T, T, string, ElementList|Element|string> $elementIso */
         $elementIso = $this->elementEncoder->iso($context);
         $isList = $meta->isList()->unwrapOr(false);
 
@@ -72,7 +74,7 @@ final class OptionalElementEncoder implements Feature\ElementAware, Feature\Opti
                     return null;
                 }
 
-                /** @var Iso<T|null, ElementList|Element|non-empty-string> $elementIso */
+                /** @var Iso<T|null, T|null, ElementList|Element|non-empty-string, ElementList|Element|non-empty-string> $elementIso */
                 return $elementIso->from($xml);
             }
         );

--- a/src/Encoder/RepeatingElementEncoder.php
+++ b/src/Encoder/RepeatingElementEncoder.php
@@ -12,12 +12,12 @@ use function Psl\Vec\map;
 
 /**
  * @template T
- * @implements XmlEncoder<iterable<array-key, T>|null, string>
+ * @implements XmlEncoder<iterable<array-key, T>|null, iterable<array-key, T>, string, Element|ElementList|string>
  */
 final class RepeatingElementEncoder implements Feature\ElementAware, Feature\ListAware, XmlEncoder
 {
     /**
-     * @param XmlEncoder<T, string> $typeEncoder
+     * @param XmlEncoder<T, T, string|null, Element|ElementList|string|null> $typeEncoder
      */
     public function __construct(
         private readonly XmlEncoder $typeEncoder
@@ -25,7 +25,7 @@ final class RepeatingElementEncoder implements Feature\ElementAware, Feature\Lis
     }
 
     /**
-     * @return Iso<iterable<array-key, T>|null, string>
+     * @return Iso<iterable<array-key, T>|null, iterable<array-key, T>, string, Element|ElementList|string>
      */
     public function iso(Context $context): Iso
     {
@@ -47,8 +47,12 @@ final class RepeatingElementEncoder implements Feature\ElementAware, Feature\Lis
                         $raw ?? [],
                         /**
                          * @param T $item
+                         *
+                         * The inner XML output slot is `string|null` because it mirrors the shared aggregate
+                         * encoder type, but element encoders always produce a string in the to() direction;
+                         * the cast only collapses type-level nullability inherited from the aggregate.
                          */
-                        static fn (mixed $item): string => $innerIso->to($item)
+                        static fn (mixed $item): string => (string) $innerIso->to($item)
                     ),
                     ''
                 );
@@ -64,7 +68,7 @@ final class RepeatingElementEncoder implements Feature\ElementAware, Feature\Lis
                     default => ElementList::fromString('<list>'.$xml.'</list>')->elements()
                 };
 
-                /** @var Iso<T|null, Element|non-empty-string> $innerIso */
+                /** @var Iso<T|null, T|null, Element|non-empty-string, Element|non-empty-string> $innerIso */
                 return map(
                     $elements,
                     static fn (Element $element): mixed => $innerIso->from($element)

--- a/src/Encoder/SimpleType/AttributeValueEncoder.php
+++ b/src/Encoder/SimpleType/AttributeValueEncoder.php
@@ -7,15 +7,16 @@ use Soap\Encoding\Encoder\Context;
 use Soap\Encoding\Encoder\XmlEncoder;
 use Soap\Encoding\Exception\RestrictionException;
 use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 use function Psl\Type\scalar;
 
 /**
- * @implements XmlEncoder<mixed, string|null>
+ * @implements XmlEncoder<mixed, mixed, string|null, string|null>
  */
 final class AttributeValueEncoder implements XmlEncoder
 {
     /**
-     * @param XmlEncoder<mixed, string> $typeEncoder
+     * @param XmlEncoder<mixed, mixed, string, string> $typeEncoder
      */
     public function __construct(
         private readonly XmlEncoder $typeEncoder
@@ -23,7 +24,7 @@ final class AttributeValueEncoder implements XmlEncoder
     }
 
     /**
-     * @return Iso<mixed, string|null>
+     * @return Iso<mixed, mixed, string|null, string|null>
      */
     public function iso(Context $context): Iso
     {
@@ -36,9 +37,9 @@ final class AttributeValueEncoder implements XmlEncoder
     }
 
     /**
-     * @param Iso<mixed, string> $typeIso
+     * @param IsoInterface<mixed, mixed, string, string> $typeIso
      */
-    private function to(Context $context, Iso $typeIso, mixed $value): ?string
+    private function to(Context $context, IsoInterface $typeIso, mixed $value): ?string
     {
         $meta = $context->type->getMeta();
         $fixed = $meta->fixed()
@@ -56,9 +57,9 @@ final class AttributeValueEncoder implements XmlEncoder
     }
 
     /**
-     * @param Iso<mixed, string> $typeIso
+     * @param IsoInterface<mixed, mixed, string, string> $typeIso
      */
-    private function from(Context $context, Iso $typeIso, ?string $value): mixed
+    private function from(Context $context, IsoInterface $typeIso, ?string $value): mixed
     {
         if ($value !== null) {
             return $typeIso->from($value);

--- a/src/Encoder/SimpleType/BackedEnumTypeEncoder.php
+++ b/src/Encoder/SimpleType/BackedEnumTypeEncoder.php
@@ -10,7 +10,7 @@ use VeeWee\Reflecta\Iso\Iso;
 use function Psl\Type\backed_enum;
 
 /**
- * @implements XmlEncoder<BackedEnum, string>
+ * @implements XmlEncoder<BackedEnum, BackedEnum, string, string>
  */
 final class BackedEnumTypeEncoder implements XmlEncoder
 {
@@ -23,7 +23,7 @@ final class BackedEnumTypeEncoder implements XmlEncoder
     }
 
     /**
-     * @return Iso<BackedEnum, string>
+     * @return Iso<BackedEnum, BackedEnum, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/Base64BinaryTypeEncoder.php
+++ b/src/Encoder/SimpleType/Base64BinaryTypeEncoder.php
@@ -12,12 +12,12 @@ use function Psl\Encoding\Base64\decode;
 use function Psl\Encoding\Base64\encode;
 
 /**
- * @implements XmlEncoder<string, string>
+ * @implements XmlEncoder<string, string, string, string>
  */
 final class Base64BinaryTypeEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<string, string>
+     * @return Iso<string, string, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/BoolTypeEncoder.php
+++ b/src/Encoder/SimpleType/BoolTypeEncoder.php
@@ -8,12 +8,12 @@ use Soap\Encoding\Encoder\XmlEncoder;
 use VeeWee\Reflecta\Iso\Iso;
 
 /**
- * @implements XmlEncoder<bool, string>
+ * @implements XmlEncoder<bool, bool, string, string>
  */
 final class BoolTypeEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<bool, string>
+     * @return Iso<bool, bool, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/CDataTypeEncoder.php
+++ b/src/Encoder/SimpleType/CDataTypeEncoder.php
@@ -14,12 +14,12 @@ use VeeWee\Reflecta\Iso\Iso;
  * When writing the data to the XML element, it will be wrapped in a CDATA section.
  *
  * @psalm-suppress UnusedClass
- * @implements XmlEncoder<string, string>
+ * @implements XmlEncoder<string, string, string, string>
  */
 final class CDataTypeEncoder implements Feature\CData, XmlEncoder
 {
     /**
-     * @return Iso<string, string>
+     * @return Iso<string, string, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/DateTimeTypeEncoder.php
+++ b/src/Encoder/SimpleType/DateTimeTypeEncoder.php
@@ -10,7 +10,7 @@ use Soap\Encoding\Encoder\XmlEncoder;
 use VeeWee\Reflecta\Iso\Iso;
 
 /**
- * @implements XmlEncoder<DateTimeInterface, string>
+ * @implements XmlEncoder<DateTimeInterface, DateTimeImmutable, string, string>
  */
 final class DateTimeTypeEncoder implements XmlEncoder
 {
@@ -44,7 +44,7 @@ final class DateTimeTypeEncoder implements XmlEncoder
     }
 
     /**
-     * @return Iso<DateTimeInterface, string>
+     * @return Iso<DateTimeInterface, DateTimeImmutable, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/DateTypeEncoder.php
+++ b/src/Encoder/SimpleType/DateTypeEncoder.php
@@ -10,7 +10,7 @@ use Soap\Encoding\Encoder\XmlEncoder;
 use VeeWee\Reflecta\Iso\Iso;
 
 /**
- * @implements XmlEncoder<DateTimeInterface, string>
+ * @implements XmlEncoder<DateTimeInterface, DateTimeImmutable, string, string>
  */
 final class DateTypeEncoder implements XmlEncoder
 {
@@ -44,13 +44,17 @@ final class DateTypeEncoder implements XmlEncoder
     }
 
     /**
-     * @return Iso<DateTimeInterface, string>
+     * @return Iso<DateTimeInterface, DateTimeImmutable, string, string>
      */
     public function iso(Context $context): Iso
     {
         return (new Iso(
             fn (DateTimeInterface $value): string => $value->format($this->dateFormat),
-            static fn (string $value): DateTimeInterface => (new DateTimeImmutable($value))->setTime(0, 0),
+            static function (string $value): DateTimeImmutable {
+                /** @var DateTimeImmutable $result */
+                $result = (new DateTimeImmutable($value))->setTime(0, 0);
+                return $result;
+            },
         ));
     }
 }

--- a/src/Encoder/SimpleType/EncoderDetector.php
+++ b/src/Encoder/SimpleType/EncoderDetector.php
@@ -9,6 +9,8 @@ use Soap\Encoding\Encoder\Feature;
 use Soap\Encoding\Encoder\OptionalElementEncoder;
 use Soap\Encoding\Encoder\XmlEncoder;
 use Soap\Encoding\Encoder\XsiTypeEncoder;
+use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\XsdType;
 use function Psl\Iter\any;
 
@@ -23,7 +25,7 @@ final class EncoderDetector
     }
 
     /**
-     * @return XmlEncoder<mixed, string|null>
+     * @return XmlEncoder<mixed, mixed, string|null, ElementList|Element|string|null>
      */
     public function __invoke(Context $context): XmlEncoder
     {
@@ -34,8 +36,8 @@ final class EncoderDetector
     }
 
     /**
-     * @param XmlEncoder<mixed, string> $encoder
-     * @return XmlEncoder<mixed, string|null>
+     * @param XmlEncoder<mixed, mixed, string, string> $encoder
+     * @return XmlEncoder<mixed, mixed, string|null, ElementList|Element|string|null>
      */
     private function enhanceEncoder(Context $context, XmlEncoder $encoder): XmlEncoder
     {
@@ -68,7 +70,7 @@ final class EncoderDetector
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
+     * @return XmlEncoder<mixed, mixed, string, string>
      */
     private function detectSimpleTypeEncoder(Context $context): XmlEncoder
     {

--- a/src/Encoder/SimpleType/FloatTypeEncoder.php
+++ b/src/Encoder/SimpleType/FloatTypeEncoder.php
@@ -10,12 +10,12 @@ use function Psl\Type\float;
 use function Psl\Type\numeric_string;
 
 /**
- * @implements XmlEncoder<float, string>
+ * @implements XmlEncoder<float, float, numeric-string, string>
  */
 final class FloatTypeEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<float, string>
+     * @return Iso<float, float, numeric-string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/HexBinaryTypeEncoder.php
+++ b/src/Encoder/SimpleType/HexBinaryTypeEncoder.php
@@ -11,12 +11,12 @@ use function Psl\Encoding\Hex\decode;
 use function Psl\Encoding\Hex\encode;
 
 /**
- * @implements XmlEncoder<string, string>
+ * @implements XmlEncoder<string, string, string, string>
  */
 final class HexBinaryTypeEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<string, string>
+     * @return Iso<string, string, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/IntTypeEncoder.php
+++ b/src/Encoder/SimpleType/IntTypeEncoder.php
@@ -10,12 +10,12 @@ use function Psl\Type\int;
 use function Psl\Type\string;
 
 /**
- * @implements XmlEncoder<int, string>
+ * @implements XmlEncoder<int, int, string, string>
  */
 final class IntTypeEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<int, string>
+     * @return Iso<int, int, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/ScalarTypeEncoder.php
+++ b/src/Encoder/SimpleType/ScalarTypeEncoder.php
@@ -14,7 +14,7 @@ use function is_int;
 use function is_string;
 
 /**
- * @implements XmlEncoder<mixed, string>
+ * @implements XmlEncoder<mixed, scalar, string, string>
  */
 final class ScalarTypeEncoder implements XmlEncoder
 {
@@ -29,7 +29,7 @@ final class ScalarTypeEncoder implements XmlEncoder
     /**
      * Will parse scalar values but accepts mixed to throw exceptions on invalid types.
      *
-     * @return Iso<mixed, string>
+     * @return Iso<mixed, scalar, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/SimpleListEncoder.php
+++ b/src/Encoder/SimpleType/SimpleListEncoder.php
@@ -14,12 +14,12 @@ use function Psl\Vec\filter;
 use function Psl\Vec\map;
 
 /**
- * @implements XmlEncoder<array, string>
+ * @implements XmlEncoder<array|string, list<mixed>, string, string>
  */
 final class SimpleListEncoder implements Feature\ListAware, XmlEncoder
 {
     /**
-     * @param XmlEncoder<mixed, string> $typeEncoder
+     * @param XmlEncoder<mixed, mixed, string, string> $typeEncoder
      */
     public function __construct(
         private readonly XmlEncoder $typeEncoder
@@ -27,9 +27,7 @@ final class SimpleListEncoder implements Feature\ListAware, XmlEncoder
     }
 
     /**
-     * @psalm-suppress ImplementedReturnTypeMismatch - ISO<S,A> does not ISO<S,T,A,B>
-     *
-     * @return Iso<string|array, string>
+     * @return Iso<array|string, list<mixed>, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SimpleType/StringTypeEncoder.php
+++ b/src/Encoder/SimpleType/StringTypeEncoder.php
@@ -9,12 +9,12 @@ use Soap\Encoding\Restriction\WhitespaceRestriction;
 use VeeWee\Reflecta\Iso\Iso;
 
 /**
- * @implements XmlEncoder<string, string>
+ * @implements XmlEncoder<string, string, string, string>
  */
 final class StringTypeEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<string, string>
+     * @return Iso<string, string, string, string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SoapEnc/ApacheMapEncoder.php
+++ b/src/Encoder/SoapEnc/ApacheMapEncoder.php
@@ -23,12 +23,12 @@ use function VeeWee\Xml\Writer\Builder\element;
 use function VeeWee\Xml\Writer\Builder\value as buildValue;
 
 /**
- * @implements XmlEncoder<array<array-key, mixed>, non-empty-string>
+ * @implements XmlEncoder<array<array-key, mixed>, array<array-key, mixed>, non-empty-string, non-empty-string>
  */
 final class ApacheMapEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<array<array-key, mixed>, non-empty-string>
+     * @return Iso<array<array-key, mixed>, array<array-key, mixed>, non-empty-string, non-empty-string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SoapEnc/SoapArrayAccess.php
+++ b/src/Encoder/SoapEnc/SoapArrayAccess.php
@@ -4,18 +4,19 @@ namespace Soap\Encoding\Encoder\SoapEnc;
 
 use Soap\Encoding\Encoder\Context;
 use Soap\Encoding\Encoder\XmlEncoder;
+use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 use Soap\WsdlReader\Model\Definitions\BindingUse;
 use Soap\WsdlReader\Parser\Xml\QnameParser;
 use Soap\Xml\Xmlns;
-use Stringable;
 use function Psl\Result\try_catch;
 
 final class SoapArrayAccess
 {
     /**
-     * @param XmlEncoder<mixed, Stringable|string> $itemEncoder
+     * @param XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null> $itemEncoder
      */
     public function __construct(
         public readonly string $xsiType,

--- a/src/Encoder/SoapEnc/SoapArrayEncoder.php
+++ b/src/Encoder/SoapEnc/SoapArrayEncoder.php
@@ -22,12 +22,12 @@ use function VeeWee\Xml\Writer\Builder\prefixed_attribute;
 use function VeeWee\Xml\Writer\Builder\raw as buildRaw;
 
 /**
- * @implements XmlEncoder<list<mixed>, non-empty-string>
+ * @implements XmlEncoder<list<mixed>, list<mixed>, non-empty-string, non-empty-string>
  */
 final class SoapArrayEncoder implements ListAware, XmlEncoder
 {
     /**
-     * @return Iso<list<mixed>, non-empty-string>
+     * @return Iso<list<mixed>, list<mixed>, non-empty-string, non-empty-string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/SoapEnc/SoapObjectEncoder.php
+++ b/src/Encoder/SoapEnc/SoapObjectEncoder.php
@@ -21,12 +21,12 @@ use function VeeWee\Xml\Writer\Builder\element;
 use function VeeWee\Xml\Writer\Builder\value as buildValue;
 
 /**
- * @implements XmlEncoder<object, non-empty-string>
+ * @implements XmlEncoder<object, object, non-empty-string, non-empty-string>
  */
 final class SoapObjectEncoder implements XmlEncoder
 {
     /**
-     * @return Iso<object, non-empty-string>
+     * @return Iso<object, object, non-empty-string, non-empty-string>
      */
     public function iso(Context $context): Iso
     {

--- a/src/Encoder/XmlEncoder.php
+++ b/src/Encoder/XmlEncoder.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Soap\Encoding\Encoder;
 
-use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 
 /**
- * @template-covariant TData
- * @template-covariant TXml
+ * @template-covariant TDataIn
+ * @template-covariant TDataOut
+ * @template-covariant TXmlOut
+ * @template-covariant TXmlIn
  */
 interface XmlEncoder
 {
     /**
-     * @return Iso<TData, TXml>
+     * @return IsoInterface<TDataIn, TDataOut, TXmlOut, TXmlIn>
      */
-    public function iso(Context $context): Iso;
+    public function iso(Context $context): IsoInterface;
 }

--- a/src/Encoder/XsiTypeEncoder.php
+++ b/src/Encoder/XsiTypeEncoder.php
@@ -4,16 +4,18 @@ namespace Soap\Encoding\Encoder;
 
 use Soap\Encoding\TypeInference\XsiTypeDetector;
 use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 use function Psl\Type\non_empty_string;
 
 /**
- * @implements XmlEncoder<mixed, string>
+ * @implements XmlEncoder<mixed, mixed, string, Element|string>
  */
 final readonly class XsiTypeEncoder implements Feature\ElementAware, XmlEncoder
 {
     /**
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null> $encoder
      */
     public function __construct(
         private XmlEncoder $encoder
@@ -21,7 +23,7 @@ final readonly class XsiTypeEncoder implements Feature\ElementAware, XmlEncoder
     }
 
     /**
-     * @return Iso<mixed, string>
+     * @return Iso<mixed, mixed, string, Element|string>
      */
     public function iso(Context $context): Iso
     {
@@ -42,25 +44,29 @@ final readonly class XsiTypeEncoder implements Feature\ElementAware, XmlEncoder
     }
 
     /**
-     * @param Iso<mixed, string> $innerIso
+     * @param IsoInterface<mixed, mixed, string|null, Element|ElementList|string|null> $innerIso
      */
-    private function to(Iso $innerIso, mixed $value): string
+    private function to(IsoInterface $innerIso, mixed $value): string
     {
         // There is no way to know what xsi:type to use when encoding any type.
         // The type defined in the wsdl will always be used to encode the value.
         // If you want more control over the encoded type, please control how to encode by using the MatchingValueEncoder.
-        return $innerIso->to($value);
+        //
+        // The inner XML output slot is `string|null` because it mirrors the shared aggregate encoder type,
+        // but element encoders always produce a (non-empty) string in the to() direction: the cast only collapses
+        // the type-level nullability that originates from attribute encoders elsewhere in the aggregate.
+        return (string) $innerIso->to($value);
     }
 
     /**
-     * @param Iso<mixed, string> $innerIso
+     * @param IsoInterface<mixed, mixed, string|null, Element|ElementList|string|null> $innerIso
      */
-    private function from(Context $context, Iso $innerIso, Element $value): mixed
+    private function from(Context $context, IsoInterface $innerIso, Element $value): mixed
     {
         $iso = match (true) {
             $this->encoder instanceof Feature\DisregardXsiInformation => $innerIso,
             default => XsiTypeDetector::detectEncoderFromXmlElement($context, $value->element())
-                ->map(static fn (XmlEncoder $encoder): Iso => $encoder->iso($context))
+                ->map(static fn (XmlEncoder $encoder): IsoInterface => $encoder->iso($context))
                 ->unwrapOr($innerIso),
         };
 

--- a/src/EncoderRegistry.php
+++ b/src/EncoderRegistry.php
@@ -13,19 +13,20 @@ use Soap\Encoding\Encoder\SimpleType;
 use Soap\Encoding\Encoder\SoapEnc;
 use Soap\Encoding\Encoder\XmlEncoder;
 use Soap\Encoding\Formatter\QNameFormatter;
+use Soap\Encoding\Xml\Node\Element;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\XsdType;
 use Soap\WsdlReader\Metadata\Detector\ApacheMapDetector;
 use Soap\WsdlReader\Model\Definitions\EncodingStyle;
 use Soap\Xml\Xmlns;
 use stdClass;
-use Stringable;
 use function Psl\Dict\pull;
 
 final class EncoderRegistry
 {
     /**
-     * @param MutableMap<string, XmlEncoder<mixed, string>> $simpleTypeMap
-     * @param MutableMap<string, XmlEncoder<mixed, string>> $complextTypeMap
+     * @param MutableMap<string, XmlEncoder<mixed, mixed, string, string>> $simpleTypeMap
+     * @param MutableMap<string, XmlEncoder<mixed, mixed, string, Element|ElementList|string>> $complextTypeMap
      * @param int $decoderLibXmlOptions - bitmask of LIBXML_* constants https://www.php.net/manual/en/libxml.constants.php
      */
     private function __construct(
@@ -45,7 +46,7 @@ final class EncoderRegistry
         $xsd1999 = Xmlns::xsd1999()->value();
 
         return new self(
-            /** @var MutableMap<XmlEncoder<mixed, string>> */
+            /** @var MutableMap<XmlEncoder<mixed, mixed, string, string>> */
             new MutableMap([
                 // Strings:
                 $qNameFormatter($xsd, 'string') => new SimpleType\StringTypeEncoder(),
@@ -139,7 +140,7 @@ final class EncoderRegistry
                 $qNameFormatter($xsd1999, 'date') => SimpleType\DateTypeEncoder::default(),
                 $qNameFormatter($xsd1999, 'time') => new SimpleType\StringTypeEncoder(),
             ]),
-            /** @var MutableMap<XmlEncoder<mixed, string>> */
+            /** @var MutableMap<XmlEncoder<mixed, mixed, string, Element|ElementList|string>> */
             new MutableMap([
                 // SOAP 1.1 ENC
                 $qNameFormatter(EncodingStyle::SOAP_11->value, 'Array') => new SoapEnc\SoapArrayEncoder(),
@@ -227,7 +228,7 @@ final class EncoderRegistry
     /**
      * @param non-empty-string $namespace
      * @param non-empty-string $name
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, string, string> $encoder
      */
     public function addSimpleTypeConverter(string $namespace, string $name, XmlEncoder $encoder): self
     {
@@ -242,7 +243,7 @@ final class EncoderRegistry
     /**
      * @param non-empty-string $namespace
      * @param non-empty-string $name
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, string, Element|ElementList|string> $encoder
      */
     public function addComplexTypeConverter(string $namespace, string $name, XmlEncoder $encoder): self
     {
@@ -255,7 +256,7 @@ final class EncoderRegistry
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
+     * @return XmlEncoder<mixed, mixed, string, string>
      */
     public function findSimpleEncoderByXsdType(XsdType $type): XmlEncoder
     {
@@ -266,7 +267,7 @@ final class EncoderRegistry
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
+     * @return XmlEncoder<mixed, mixed, string, string>
      */
     public function findSimpleEncoderByNamespaceName(string $namespace, string $name): XmlEncoder
     {
@@ -296,7 +297,7 @@ final class EncoderRegistry
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
+     * @return XmlEncoder<mixed, mixed, string, Element|ElementList|string>
      */
     public function findComplexEncoderByXsdType(XsdType $type): XmlEncoder
     {
@@ -307,7 +308,7 @@ final class EncoderRegistry
     }
 
     /**
-     * @return XmlEncoder<mixed, string>
+     * @return XmlEncoder<mixed, mixed, string, Element|ElementList|string>
      */
     public function findComplexEncoderByNamespaceName(string $namespace, string $name): XmlEncoder
     {
@@ -337,7 +338,7 @@ final class EncoderRegistry
     }
 
     /**
-     * @return XmlEncoder<mixed, string|Stringable>
+     * @return XmlEncoder<mixed, mixed, string|null, Element|ElementList|string|null>
      */
     public function detectEncoderForContext(Context $context): XmlEncoder
     {

--- a/src/Fault/Encoder/Soap11FaultEncoder.php
+++ b/src/Fault/Encoder/Soap11FaultEncoder.php
@@ -24,7 +24,7 @@ use function VeeWee\Xml\Writer\Mapper\memory_output;
 final class Soap11FaultEncoder implements SoapFaultEncoder
 {
     /**
-     * @return Iso<Soap11Fault, non-empty-string>
+     * @return Iso<Soap11Fault, Soap11Fault, non-empty-string, non-empty-string>
      */
     public function iso(): Iso
     {

--- a/src/Fault/Encoder/Soap12FaultEncoder.php
+++ b/src/Fault/Encoder/Soap12FaultEncoder.php
@@ -25,7 +25,7 @@ final class Soap12FaultEncoder implements SoapFaultEncoder
     private const ENV_NAMESPACE = 'http://www.w3.org/2003/05/soap-envelope';
 
     /**
-     * @return Iso<Soap12Fault, non-empty-string>
+     * @return Iso<Soap12Fault, Soap12Fault, non-empty-string, non-empty-string>
      */
     public function iso(): Iso
     {

--- a/src/Fault/Encoder/SoapFaultEncoder.php
+++ b/src/Fault/Encoder/SoapFaultEncoder.php
@@ -12,7 +12,7 @@ use VeeWee\Reflecta\Iso\Iso;
 interface SoapFaultEncoder
 {
     /**
-     * @return Iso<TFault, non-empty-string>
+     * @return Iso<TFault, TFault, non-empty-string, non-empty-string>
      */
     public function iso(): Iso;
 }

--- a/src/Normalizer/PhpPropertyNameNormalizer.php
+++ b/src/Normalizer/PhpPropertyNameNormalizer.php
@@ -10,6 +10,7 @@ use function array_unshift;
 use function count;
 use function preg_split;
 use function Psl\Type\non_empty_string;
+use function ucfirst;
 
 final class PhpPropertyNameNormalizer
 {
@@ -29,7 +30,7 @@ final class PhpPropertyNameNormalizer
         }
 
         $keepUnchanged = array_shift($parts);
-        $parts = array_map(\ucfirst(...), $parts);
+        $parts = array_map(ucfirst(...), $parts);
         array_unshift($parts, $keepUnchanged);
 
         return non_empty_string()->assert(

--- a/src/TypeInference/XsiTypeDetector.php
+++ b/src/TypeInference/XsiTypeDetector.php
@@ -9,6 +9,8 @@ use Soap\Encoding\Cache\ScopedCache;
 use Soap\Encoding\Encoder\Context;
 use Soap\Encoding\Encoder\FixedIsoEncoder;
 use Soap\Encoding\EncoderRegistry;
+use Soap\Encoding\Xml\Node\Element as XmlElement;
+use Soap\Encoding\Xml\Node\ElementList;
 use Soap\Engine\Metadata\Model\XsdType;
 use Soap\WsdlReader\Parser\Xml\QnameParser;
 use Soap\Xml\Xmlns as SoapXmlns;
@@ -24,7 +26,7 @@ use function sprintf;
 final class XsiTypeDetector
 {
     /**
-     * @return ScopedCache<EncoderRegistry, FixedIsoEncoder<mixed, string>>
+     * @return ScopedCache<EncoderRegistry, FixedIsoEncoder<mixed, mixed, string|null, XmlElement|ElementList|string|null>>
      *
      * @psalm-suppress LessSpecificReturnStatement, MoreSpecificReturnType, MixedReturnStatement
      */
@@ -89,7 +91,7 @@ final class XsiTypeDetector
     }
 
     /**
-     * @return Option<FixedIsoEncoder<mixed, string>>
+     * @return Option<FixedIsoEncoder<mixed, mixed, string|null, XmlElement|ElementList|string|null>>
      */
     public static function detectEncoderFromXmlElement(Context $context, Element $element): Option
     {

--- a/src/Xml/Reader/ElementValueReader.php
+++ b/src/Xml/Reader/ElementValueReader.php
@@ -6,14 +6,14 @@ namespace Soap\Encoding\Xml\Reader;
 use Dom\Element;
 use Soap\Encoding\Encoder\Context;
 use Soap\Encoding\Encoder\XmlEncoder;
-use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 use function Psl\Type\string;
 use function VeeWee\Xml\Dom\Locator\Node\value as readValue;
 
 final class ElementValueReader
 {
     /**
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, string, string> $encoder
      * @psalm-return mixed
      */
     public function __invoke(
@@ -25,7 +25,7 @@ final class ElementValueReader
     }
 
     /**
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, string, string> $encoder
      * @psalm-return mixed
      */
     public static function forEncoder(Context $context, XmlEncoder $encoder, Element $element): mixed
@@ -36,10 +36,10 @@ final class ElementValueReader
     }
 
     /**
-     * @param Iso<mixed, string> $iso
+     * @param IsoInterface<mixed, mixed, string, string> $iso
      * @psalm-return mixed
      */
-    public static function forIso(Iso $iso, Element $element): mixed
+    public static function forIso(IsoInterface $iso, Element $element): mixed
     {
         return $iso->from(
             readValue($element, string())

--- a/src/Xml/Writer/ElementValueBuilder.php
+++ b/src/Xml/Writer/ElementValueBuilder.php
@@ -8,7 +8,7 @@ use Generator;
 use Soap\Encoding\Encoder\Context;
 use Soap\Encoding\Encoder\Feature;
 use Soap\Encoding\Encoder\XmlEncoder;
-use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Iso\IsoInterface;
 use XMLWriter;
 use function VeeWee\Xml\Writer\Builder\cdata;
 use function VeeWee\Xml\Writer\Builder\children;
@@ -25,7 +25,7 @@ final class ElementValueBuilder
     }
 
     /**
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, string, mixed> $encoder
      * @psalm-param mixed $value
      */
     public static function fromEncoder(Context $context, XmlEncoder $encoder, mixed $value): self
@@ -37,11 +37,11 @@ final class ElementValueBuilder
     }
 
     /**
-     * @param XmlEncoder<mixed, string> $encoder
-     * @param Iso<mixed, string> $iso
+     * @param XmlEncoder<mixed, mixed, mixed, mixed> $encoder
+     * @param IsoInterface<mixed, mixed, string, mixed> $iso
      * @psalm-param mixed $value
      */
-    public static function fromIso(Context $context, XmlEncoder $encoder, Iso $iso, mixed $value): self
+    public static function fromIso(Context $context, XmlEncoder $encoder, IsoInterface $iso, mixed $value): self
     {
         return new self([
             XsiAttributeBuilder::forEncodedValue($context, $encoder, $value),
@@ -58,7 +58,7 @@ final class ElementValueBuilder
     }
 
     /**
-     * @param XmlEncoder<mixed, string> $encoder
+     * @param XmlEncoder<mixed, mixed, mixed, mixed> $encoder
      * @param Closure(): string $valueProvider
      *
      * @return Closure(XMLWriter): Generator<bool>


### PR DESCRIPTION
Adopt the four-template profunctor STAB form from [veewee/reflecta#31](https://github.com/veewee/reflecta/pull/31). Every `Iso`/`Lens` annotation and generic expands from `<S, A>` to `<S, T, A, B>`. Runtime behavior is unchanged; this is a structural / type-annotation migration.

## Summary

- **Encoder interfaces** (`XmlEncoder`, `SoapMethodEncoder`, `ProvidesObject{En,De}coderLens`, `DecoratingEncoder`) gain a 4-slot signature `(TDataIn, TDataOut, TXmlOut, TXmlIn)` and are marked `@template-covariant` to match reflecta's interface posture. Concrete encoder classes stay invariant.
- **Element-aware encoders** declare their honest asymmetric shapes — `from` accepts `Element|non-empty-string` etc., reflecting the runtime fast path that was previously hidden behind 2-template unsoundness.
- **Simple-type encoders** declare their narrow real outputs (`DateTimeImmutable`, `numeric-string`, `scalar`, `list<mixed>`, …) so psalm's body inference matches the declared shape.
- **Heterogeneous storage** in `EncoderRegistry`, `ObjectAccess`, and the wrappers types its slots as `IsoInterface`/`LensInterface`/`XmlEncoder<mixed, mixed, mixed, mixed>`. Interface covariance lets concrete encoders flow into these slots without casts.
- **Wrappers** (`RepeatingElementEncoder<T>`, `OptionalElementEncoder<T>`) accept `XmlEncoder<T, T, mixed, mixed>` in their constructor — `T` binds from the inner encoder's data slots, XML slots erased because the wrapper rewrites the XML representation regardless.

## Variance posture

Mirrors reflecta's: **interface covariant, concrete invariant.** Concrete `Iso<S, T, A, B>` / `Lens<S, T, A, B>` construction and `compose()` chains still get full STAB invariance checking. `IsoInterface<S, T, A, B>` / `LensInterface<S, T, A, B>` typed slots widen polymorphically, same trade as `IEnumerable<out T>` in C#.

## Requirements

- Requires veewee/reflecta `dev-feature/stab-optics` (resolved via the `as 0.19.0` alias in `composer.json`). Once that branch ships as a real release, drop the alias.

## Test plan

- [x] `vendor/bin/psalm --no-cache` green (no errors)
- [x] `vendor/bin/phpunit --no-coverage` green (564 tests, 1156 assertions)
- [x] CI green
- [x] Downstream check: `php-soap/psr18-attachments-middleware` migration on top of this branch ([linked PR](#))